### PR TITLE
Fix content-length if multi-byte characters occur in body of PUT/POST.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -103,6 +103,9 @@ extend(Connection.prototype, {
       } else {
         body = String(body);
       }
+      if (typeof body === 'string') {
+        body = new Buffer(body, "utf-8");
+      }
       headers['content-length'] = body.length;
     }
 


### PR DESCRIPTION
For PUT and POST requests (like for example created in the <collection>.save method of the driver, the body is first transformed to a (UTF-16) string, because this is what V8 does. Then body.length is the number of unicode characters rather than the byte length of the body in the HTTP request. This pull request explicitly converts the body to UTF-8 in a Buffer, sets the content-length header then correctly, and hands the buffer on in the "body" attribute. Since this buffer is later written into the request object, the right thing happens.
This fixes a bug observed by Claudius with saving documents with many unicode characters.