### PR TITLE
Make arangojs work on Windows

### DIFF
--- a/lib/util/request.js
+++ b/lib/util/request.js
@@ -3,7 +3,7 @@ var http = require('http');
 var https = require('https');
 var parseUrl = require('url').parse;
 var once = require('./once');
-var joinPath = require('path').join;
+var joinPath = require('path').posix.join;
 var LinkedList = require('linkedlist');
 
 function rawCopy(obj) {


### PR DESCRIPTION
Since paths used are for http(s) requests, they should always use forward slash and not backslash for Windows.