### PR TITLE
Fix catch must be followed by whitespace in src/cursor.js

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -105,7 +105,7 @@ export default class ArrayCursor {
         else {
           this._more(err => err ? callback(err) : loop());
         }
-      } catch(e) {
+      } catch (e) {
         callback(e);
       }
     };
@@ -128,7 +128,7 @@ export default class ArrayCursor {
         else {
           this._more(err => err ? callback(err) : loop());
         }
-      } catch(e) {
+      } catch (e) {
         callback(e);
       }
     };
@@ -150,7 +150,7 @@ export default class ArrayCursor {
         else {
           this._more(err => err ? callback(err) : loop());
         }
-      } catch(e) {
+      } catch (e) {
         callback(e);
       }
     };
@@ -175,7 +175,7 @@ export default class ArrayCursor {
         else {
           this._more(err => err ? callback(err) : loop());
         }
-      } catch(e) {
+      } catch (e) {
         callback(e);
       }
     };


### PR DESCRIPTION
Actually npm run lint failed during install so this pr fix the lint error in cursor.js