### PR TITLE
Rebuild the Cursor object

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,29 +974,6 @@ cursor.reduce(add, function (err, result) {
 
 ```
 
-### cursor.rewind
-
-`cursor.rewind(): cursor`
-
-Rewinds the cursor. Returns the cursor.
-
-**Examples**
-
-```js
-// query result: [1, 2, 3, 4, 5]
-cursor.all(function (err, result) {
-    if (err) return console.error(err);
-    result; // [1, 2, 3, 4, 5]
-    cursor.hasNext() === false;
-    cursor.rewind();
-    cursor.hasNext() === true;
-    cursor.next(function (err, value) {
-        if (err) return console.error(err);
-        value === 1;
-    });
-});
-```
-
 ## Route API
 
 *Route* instances provide access for arbitrary HTTP requests. This allows easy access to Foxx apps and other HTTP APIs not covered by the driver itself.

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -184,8 +184,4 @@ export default class ArrayCursor {
     return promise;
   }
 
-  rewind() {
-    //this._index = 0;
-    return this;
-  }
 }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -29,8 +29,9 @@ export default class ArrayCursor {
       this._api.put(`cursor/${this._id}`, (err, res) => {
         if (err) callback(err);
         else {
-          this._result.push.apply(this._result, res.body.result);
+          this._result = res.body.result;
           this._hasMore = res.body.hasMore;
+          this._index = 0;
           callback(null, this);
         }
       });
@@ -58,7 +59,7 @@ export default class ArrayCursor {
     else {
       if (!this._hasMore) callback(null);
       else {
-        this._more(err => err ? callback(err) : next());
+        this._more(err => err ? callback(err) : this.rewind().next());
       }
     }
     return promise;
@@ -86,7 +87,6 @@ export default class ArrayCursor {
         callback(e);
       }
     };
-    this._index = 0;
     loop();
     return promise;
   }
@@ -109,7 +109,6 @@ export default class ArrayCursor {
         callback(e);
       }
     };
-    this._index = 0;
     loop();
     return promise;
   }
@@ -132,7 +131,6 @@ export default class ArrayCursor {
         callback(e);
       }
     };
-    this._index = 0;
     loop();
     return promise;
   }
@@ -154,7 +152,6 @@ export default class ArrayCursor {
         callback(e);
       }
     };
-    this._index = 0;
     loop();
     return promise;
   }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -62,7 +62,7 @@ export default class ArrayCursor {
   }
 
   hasNext() {
-    return (this._hasMore || this._result.length);
+    return Boolean(this._hasMore || this._result.length);
   }
 
   each(fn, cb) {


### PR DESCRIPTION
Hi @pluma,

I've found that the issue #59 is still happening, and i thought i could help with that :smiley:.

**Problem:**

If you want to iterate over a collection with the method `#_each`, or any other, what happens internally, as you already know :smile:, is this:

  * The cursor is exhausted.
  * Then the cursor is updated (`#_more`) with more results.
  * Then continues with the loop.

But when the cursor is updated, the new results are appended (via `Array#push`) to the old ones, for small collections this may work, but not with the large ones, because you don't normally have this amount of RAM to store the documents.

**Solution:**

Well they may be other solutions but the one that occurs me and that I've tested in my collections, is the one that instead of appending the new documents to the old ones, replace the old ones with the new ones.

I've implemented a raw solution that works (Not ready to be merge), but it still has some issues to solve (I'm working on them).

Before continuing with it, would like to know you opinion to the Problem and the Solution, if I should continue or not with it, or if there is another solution.

If you like it, i would like to discuss the implementation with you :smile: 