### PR TITLE
When using the Cursro#all the this._result must have length = 0

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -40,7 +40,13 @@ export default class ArrayCursor {
     const {promise, callback} = this._connection.promisify(cb);
     this._drain(err => {
       if (err) callback(err);
-      else callback(null, this._result);
+      else {
+        let result = [];
+        while (this._result.length) {
+          result.push(this._result.shift());
+        }
+        callback(null, result);
+      }
     });
     return promise;
   }


### PR DESCRIPTION
Instead of just returning all the results of the cursor, the results array need to be exhausted, or the [documentation](https://github.com/arangodb/arangojs#cursorall) need to be changed.