### PR TITLE
Fix the creation of collection when specifying a type

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -76,7 +76,7 @@ class BaseCollection {
     const {promise, callback} = this._connection.promisify(cb);
     this._api.post(
       'collection',
-      extend({}, properties, {name: this.name, type: this.type}),
+      extend({}, {type: this.type}, properties, {name: this.name}),
       (err, res) => err ? callback(err) : callback(null, res.body)
     );
     return promise;


### PR DESCRIPTION
Fix a bug where it was impossible to create a collection of type 3

**src/collection.js**

Old code, was overriding the type in properties
```javascript
extend({}, properties, {name: this.name, type: this.type}),
```

New code, allow properties to override the type
```javascript
extend({}, {type: this.type}, properties, {name: this.name}),
```