### PR TITLE
Wrong variable

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -36,7 +36,7 @@ class BaseCollection {
   }
 
   _indexHandle (indexHandle) {
-    if (typeof documentHandle !== 'string') {
+    if (typeof indexHandle !== 'string') {
       if (indexHandle.id) {
         return indexHandle.id
       }


### PR DESCRIPTION
_indexHandle was using a wrong variable on its `typeof` test