### PR TITLE
Fix misspelled endpoint in Cursor

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -2,7 +2,7 @@ export default class ArrayCursor {
   constructor (connection, body) {
     this.extra = body.extra
     this._connection = connection
-    this._api = this._connection.route('_api')
+    this._api = this._connection.route('/_api')
     this._result = body.result
     this._hasMore = Boolean(body.hasMore)
     this._id = body.id


### PR DESCRIPTION
This misspelling causes to fail in fetching a large results over batchSize.
This PR fixes it.