### PR TITLE
Exposing arangojs in browser bundle.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "chai": "3.5.0",
     "core-js": "2.4.0",
     "coveralls": "2.11.9",
-    "expose-loader": "0.7.1",
     "istanbul": "0.4.3",
     "json-loader": "0.5.4",
     "mocha": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "chai": "3.5.0",
     "core-js": "2.4.0",
     "coveralls": "2.11.9",
+    "expose-loader": "0.7.1",
     "istanbul": "0.4.3",
     "json-loader": "0.5.4",
     "mocha": "2.5.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,11 +6,11 @@ module.exports = {
   entry: resolve(__dirname, 'src/index.js'),
   output: {
     path: __dirname,
-    filename: 'arangojs.min.js'
+    filename: 'arangojs.min.js',
+    library: 'arangojs'
   },
   module: {
     loaders: [
-      {test: /index\.js$/, loader: 'expose?arangojs'},
       {test: /\.js$/, loader: 'babel-loader'},
       {test: /\.json$/, loader: 'json-loader'}
     ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   module: {
     loaders: [
+      {test: /index\.js$/, loader: 'expose?arangojs'},
       {test: /\.js$/, loader: 'babel-loader'},
       {test: /\.json$/, loader: 'json-loader'}
     ]


### PR DESCRIPTION
Fixing #245, by exposing a global `arangojs` var.