### PR TITLE
Xhr fixes

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -68,7 +68,7 @@ export default class Connection {
       opts.headers['content-type'] = contentType
     }
 
-    if (!opts.headers.hasOwnProperty('content-length')) {
+    if (typeof window === "undefined" && !opts.headers.hasOwnProperty('content-length')) {
       opts.headers['content-length'] = body ? byteLength(body, 'utf-8') : 0
     }
 

--- a/src/util/request.web.js
+++ b/src/util/request.web.js
@@ -46,6 +46,12 @@ export default function (baseUrl, options) {
 
   return function request ({method, url, headers, body}, cb) {
     const auth = typeof username === 'string' ? {username, password} : {}
+
+    if(typeof window !== "undefined" && auth.username !== undefined && headers['Authorization'] === undefined) {
+      const btoa = window.btoa ? window.btoa : base64.encode;
+      headers['Authorization'] = "Basic " + btoa(auth.username + ":" + auth.password);
+    }
+
     const urlParts = {
       ...baseUrlParts,
       pathname: url.pathname ? (


### PR DESCRIPTION
Here are a couple of fixes for browser ajax requests. 

The first one is preventing setting the `content-length` header, it's not allowed to modify that header in xhr.

Second one is adding an `Authorization` header when appropriate, so requests works when server authentication is on.

While doing this I also found a bug in one of your dependencies, I've made a PR for that and I hope it will be accepted: https://github.com/Raynos/xhr/pull/120
