### PR TITLE
Fix #274 - Cursor.all too slow

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -43,10 +43,8 @@ export default class ArrayCursor {
     this._drain((err) => {
       if (err) callback(err)
       else {
-        let result = []
-        while (this._result.length) {
-          result.push(this._result.shift())
-        }
+        const result = this._result;
+        this._result = [];
         callback(null, result)
       }
     })


### PR DESCRIPTION
Why do not return ```this.result``` and set it to empty array.
I think it is unnecessarily crawl ```this.result``` and deleting individual elements of the array