### PR TITLE
Typescript definition file

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "directories": {
     "lib": "lib"
   },
+  "typings": "arangojs.d.ts",
   "scripts": {
     "test": "mocha --growl",
     "lint": "snazzy --verbose src/**/*.js test/**/*.js",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "lib/",
+    "package.json",
+    "arangojs.d.ts",
+    "README.md",
+    "LICENSE"
+  ],
   "typings": "arangojs.d.ts",
   "scripts": {
     "test": "mocha --growl",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,6 @@
   "directories": {
     "lib": "lib"
   },
-  "files": [
-    "lib/",
-    "package.json",
-    "README.md",
-    "LICENSE"
-  ],
   "scripts": {
     "test": "mocha --growl",
     "lint": "snazzy --verbose src/**/*.js test/**/*.js",


### PR DESCRIPTION
Dear guys,

After deleting arangojs and reinstalling it via npm, I figured out that the typescript definition file is not part of it. I would like to suggest that the `arangojs.d.ts` file is added to the the npm respository and the `package.json`. It is also possible to transfer the file into the lib folder (for better consistency rename it to `index.d.ts` in this case) and prepend the lib folder to all corresponding paths within the package.json accordingly, e.g. `typings: "lib/index.d.ts"`.