### PR TITLE
Fix geo index creation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2194,7 +2194,7 @@ For more information on the properties of the *opts* object see [the HTTP API fo
 var db = require('arangojs')();
 var collection = db.collection('some-collection');
 
-collection.createGeoIndex(['longitude', 'latitude'])
+collection.createGeoIndex(['latitude', 'longitude'])
 .then(index => {
     index.id; // the index's handle
     index.fields; // ['longitude', 'latitude']


### PR DESCRIPTION
Fix latitude and longitude field order when creating a geo index. The example showed the longitude first but the correct order is latitude first, as documented in ArangoDB's documentation [here](https://docs.arangodb.com/3.0/Manual/Indexing/Geo.html#accessing-geo-indexes-from-the-shell).

Thanks for making Arango.