### PR TITLE
fix(typings): explicitly type aqlQuery rest spread to any[]

### DIFF
--- a/arangojs.d.ts
+++ b/arangojs.d.ts
@@ -104,7 +104,7 @@ declare module "arangojs" {
          *
          * Any Collection instances will automatically be converted to collection bind variables
          */
-        aqlQuery(strings: string[], ...args): Promise<Cursor>;
+        aqlQuery(strings: string[], ...args: any[]): Promise<Cursor>;
         /**
          * Fetches a list of all AQL user functions registered with the database
          */


### PR DESCRIPTION
If arangojs is used in a project which has configured the TypeScript compiler to not allow implicit any, compilation will fail unless all non inferable types are at least explicitly declared as any.