### PR TITLE
Pass error to callback if res body toString fails

### DIFF
--- a/src/util/request.js
+++ b/src/util/request.js
@@ -71,11 +71,15 @@ export default function (baseUrl, agentOptions, agent) {
         res
         .on('data', (chunk) => data.push(chunk))
         .on('end', () => {
-          res.body = Buffer.concat(data)
-          if (!expectBinary) {
-            res.body = res.body.toString('utf-8')
+          try {
+            res.body = Buffer.concat(data)
+            if (!expectBinary) {
+              res.body = res.body.toString('utf-8')
+            }
+            callback(null, res)
+          } catch (err) {
+            callback(err)
           }
-          callback(null, res)
         })
       })
       req.on('error', (err) => {


### PR DESCRIPTION
If the Buffer of the response body is too big, `toString` can fail. These changes catch such errors and pass them to the callback.