### PR TITLE
Fixed wrong accessor in GraphEdgeCollectin.edge

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -114,7 +114,7 @@ export class GraphEdgeCollection extends EdgeCollection {
     const res = await this._gharial.get(
       `/${this._documentHandle(documentHandle)}`
     );
-    return res.body.graph;
+    return res.body.edge;
   }
 
   async save(data: any, opts?: { waitForSync?: boolean }): Promise<any>;


### PR DESCRIPTION
the method returned undefined because result
of the edge operation does not returned graph.

Instead it returned edge.

changed from res.body.graph to res.body.edge
fixes: https://github.com/arangodb/arangojs/issues/499