### PR TITLE
Misspelled "opts.spath" leads to 400 http errors

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -25,7 +25,7 @@ export class Route {
 
   request({ method, path, headers = {}, ...opts }: any) {
     if (!path) opts.path = "";
-    else if (this._path && path.charAt(0) !== "/") opts.spath = `/${path}`;
+    else if (this._path && path.charAt(0) !== "/") opts.path = `/${path}`;
     else opts.path = path;
     opts.basePath = this._path;
     opts.headers = { ...this._headers, ...headers };


### PR DESCRIPTION
because it was misspelled `opts.spath`, appending a missing leading slash wasn't working within `route/request` and therefore e.g. calling endpoint `POST /_api/gharial/{graph-name}/vertex/{collection-name}` missed the `{collection-name}` part, leading to error 400 `child "collection" fails because ["collection" is required]` when trying to add a vertex document into a vertex collection via the Http API.