### PR TITLE
Implement graceful document fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added `maxRetries` option to configuration to control retry behavior
 
+- Added `collection.documentExists` method
+
 - Added `graceful` option to `collection.document`
 
 ## [6.4.0] - 2018-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
   This behavior can be controlled using the `maxRetries` option.
 
+- Renamed `EdgeCollection#edge` to `EdgeCollection#document`
+
+  `EdgeCollection#edge` is now an alias for the `document` method.
+
+- Renamed `GraphEdgeCollection#edge` to `GraphEdgeCollection#document`
+
+  `GraphEdgeCollection#edge` is now an alias for the `document` method.
+
+- Renamed `GraphVertexCollection#vertex` to `GraphVertexCollection#document`
+
+  `GraphVertexCollection#vertex` is now an alias for the `document` method.
+
 ### Added
 
 - Added `maxRetries` option to configuration to control retry behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added `maxRetries` option to configuration to control retry behavior
 
+- Added `graceful` option to `collection.document`
+
 ## [6.4.0] - 2018-07-06
 
 ### Changed

--- a/docs/Drivers/JS/Reference/Collection/DocumentCollection.md
+++ b/docs/Drivers/JS/Reference/Collection/DocumentCollection.md
@@ -5,17 +5,22 @@ The _DocumentCollection API_ extends the
 
 ## documentCollection.document
 
-`async documentCollection.document(documentHandle): Object`
+`async documentCollection.document(documentHandle, [graceful]): Object`
 
 Retrieves the document with the given _documentHandle_ from the collection.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve. This can be either the `_id` or the
   `_key` of a document in the collection, or a document (i.e. an object with an
   `_id` or `_key` property).
+
+- **graceful**: `boolean` (Default: `false`)
+
+  If set to `true`, the method will return `null` instead of throwing an error
+  if the document does not exist.
 
 **Examples**
 
@@ -44,6 +49,13 @@ try {
   // something went wrong or
   // the document does not exist
 }
+
+// -- or --
+
+const doc = await collection.document('some-key', true);
+if (doc === null) {
+  // the document does not exist
+}
 ```
 
 ## documentCollection.save
@@ -55,38 +67,38 @@ the document's metadata.
 
 **Arguments**
 
-* **data**: `Object`
+- **data**: `Object`
 
   The data of the new document, may include a `_key`.
 
-* **opts**: `Object` (optional)
+- **opts**: `Object` (optional)
 
   If _opts_ is set, it must be an object with any of the following properties:
 
-  * **waitForSync**: `boolean` (Default: `false`)
+  - **waitForSync**: `boolean` (Default: `false`)
 
     Wait until document has been synced to disk.
 
-  * **returnNew**: `boolean` (Default: `false`)
+  - **returnNew**: `boolean` (Default: `false`)
 
     If set to `true`, return additionally the complete new documents under the
     attribute `new` in the result.
 
-  * **returnOld**: `boolean` (Default: `false`)
+  - **returnOld**: `boolean` (Default: `false`)
 
     If set to `true`, return additionally the complete old documents under the
     attribute `old` in the result.
 
-  * **silent**: `boolean` (Default: `false`)
+  - **silent**: `boolean` (Default: `false`)
 
     If set to true, an empty object will be returned as response. No meta-data
     will be returned for the created document. This option can be used to save
     some network traffic.
 
-  * **overwrite**: `boolean` (Default: `false`)
+  - **overwrite**: `boolean` (Default: `false`)
 
     If set to true, the insert becomes a replace-insert. If a document with the
-    same _key already exists the new document is not rejected with unique
+    same \_key already exists the new document is not rejected with unique
     constraint violated but will replace the old document.
 
 If a boolean is passed instead of an options object, it will be interpreted as

--- a/docs/Drivers/JS/Reference/Collection/DocumentCollection.md
+++ b/docs/Drivers/JS/Reference/Collection/DocumentCollection.md
@@ -58,6 +58,32 @@ if (doc === null) {
 }
 ```
 
+## documentCollection.documentExists
+
+`async documentCollection.documentExists(documentHandle): boolean`
+
+Checks whether the document with the given _documentHandle_ exists.
+
+**Arguments**
+
+- **documentHandle**: `string`
+
+  The handle of the document to retrieve. This can be either the `_id` or the
+  `_key` of a document in the collection, or a document (i.e. an object with an
+  `_id` or `_key` property).
+
+**Examples**
+
+```js
+const db = new Database();
+const collection = db.collection('my-docs');
+
+const exists = await collection.documentExists('some-key');
+if (exists === false) {
+  // the document does not exist
+}
+```
+
 ## documentCollection.save
 
 `async documentCollection.save(data, [opts]): Object`

--- a/docs/Drivers/JS/Reference/Collection/EdgeCollection.md
+++ b/docs/Drivers/JS/Reference/Collection/EdgeCollection.md
@@ -3,9 +3,11 @@
 The _EdgeCollection API_ extends the
 [_Collection API_](README.md) with the following methods.
 
-## edgeCollection.edge
+## edgeCollection.document
 
-`async edgeCollection.edge(documentHandle, [graceful]): Object`
+`async edgeCollection.document(documentHandle, [graceful]): Object`
+
+Alias: `edgeCollection.edge`.
 
 Retrieves the edge with the given _documentHandle_ from the collection.
 
@@ -28,21 +30,21 @@ Retrieves the edge with the given _documentHandle_ from the collection.
 const db = new Database();
 const collection = db.edgeCollection('edges');
 
-const edge = await collection.edge('some-key');
+const edge = await collection.document('some-key');
 // the edge exists
 assert.equal(edge._key, 'some-key');
 assert.equal(edge._id, 'edges/some-key');
 
 // -- or --
 
-const edge = await collection.edge('edges/some-key');
+const edge = await collection.document('edges/some-key');
 // the edge exists
 assert.equal(edge._key, 'some-key');
 assert.equal(edge._id, 'edges/some-key');
 
 // -- or --
 
-const edge = await collection.edge('some-key', true);
+const edge = await collection.document('some-key', true);
 if (edge === null) {
   // the edge does not exist
 }

--- a/docs/Drivers/JS/Reference/Collection/EdgeCollection.md
+++ b/docs/Drivers/JS/Reference/Collection/EdgeCollection.md
@@ -5,17 +5,22 @@ The _EdgeCollection API_ extends the
 
 ## edgeCollection.edge
 
-`async edgeCollection.edge(documentHandle): Object`
+`async edgeCollection.edge(documentHandle, [graceful]): Object`
 
 Retrieves the edge with the given _documentHandle_ from the collection.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the edge to retrieve. This can be either the `_id` or the `_key`
   of an edge in the collection, or an edge (i.e. an object with an `_id` or
   `_key` property).
+
+* **graceful**: `boolean` (Default: `false`)
+
+  If set to `true`, the method will return `null` instead of throwing an error
+  if the edge does not exist.
 
 **Examples**
 
@@ -34,6 +39,13 @@ const edge = await collection.edge('edges/some-key');
 // the edge exists
 assert.equal(edge._key, 'some-key');
 assert.equal(edge._id, 'edges/some-key');
+
+// -- or --
+
+const edge = await collection.edge('some-key', true);
+if (edge === null) {
+  // the edge does not exist
+}
 ```
 
 ## edgeCollection.save
@@ -45,51 +57,51 @@ _data_ and returns an object containing the edge's metadata.
 
 **Arguments**
 
-* **data**: `Object`
+- **data**: `Object`
 
   The data of the new edge. If _fromId_ and _toId_ are not specified, the _data_
   needs to contain the properties `_from` and `_to`.
 
-* **fromId**: `string` (optional)
+- **fromId**: `string` (optional)
 
   The handle of the start vertex of this edge. This can be either the `_id` of a
   document in the database, the `_key` of an edge in the collection, or a
   document (i.e. an object with an `_id` or `_key` property).
 
-* **toId**: `string` (optional)
+- **toId**: `string` (optional)
 
   The handle of the end vertex of this edge. This can be either the `_id` of a
   document in the database, the `_key` of an edge in the collection, or a
   document (i.e. an object with an `_id` or `_key` property).
 
-* **opts**: `Object` (optional)
+- **opts**: `Object` (optional)
 
   If _opts_ is set, it must be an object with any of the following properties:
 
-  * **waitForSync**: `boolean` (Default: `false`)
+  - **waitForSync**: `boolean` (Default: `false`)
 
     Wait until document has been synced to disk.
 
-  * **returnNew**: `boolean` (Default: `false`)
+  - **returnNew**: `boolean` (Default: `false`)
 
     If set to `true`, return additionally the complete new documents under the
     attribute `new` in the result.
 
-  * **returnOld**: `boolean` (Default: `false`)
+  - **returnOld**: `boolean` (Default: `false`)
 
     If set to `true`, return additionally the complete old documents under the
     attribute `old` in the result.
 
-  * **silent**: `boolean` (Default: `false`)
+  - **silent**: `boolean` (Default: `false`)
 
     If set to true, an empty object will be returned as response. No meta-data
     will be returned for the created document. This option can be used to save
     some network traffic.
 
-  * **overwrite**: `boolean` (Default: `false`)
+  - **overwrite**: `boolean` (Default: `false`)
 
     If set to true, the insert becomes a replace-insert. If a document with the
-    same _key already exists the new document is not rejected with unique
+    same \_key already exists the new document is not rejected with unique
     constraint violated but will replace the old document.
 
 If a boolean is passed instead of an options object, it will be interpreted as
@@ -133,7 +145,7 @@ Retrieves a list of all edges of the document with the given _documentHandle_.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve the edges of. This can be either the
   `_id` of a document in the database, the `_key` of an edge in the collection,
@@ -164,7 +176,7 @@ _documentHandle_.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve the edges of. This can be either the
   `_id` of a document in the database, the `_key` of an edge in the collection,
@@ -195,7 +207,7 @@ _documentHandle_.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve the edges of. This can be either the
   `_id` of a document in the database, the `_key` of an edge in the collection,
@@ -226,13 +238,13 @@ contained in this edge collection.
 
 **Arguments**
 
-* **startVertex**: `string`
+- **startVertex**: `string`
 
   The handle of the start vertex. This can be either the `_id` of a document in
   the database, the `_key` of an edge in the collection, or a document (i.e. an
   object with an `_id` or `_key` property).
 
-* **opts**: `Object`
+- **opts**: `Object`
 
   See
   [the HTTP API documentation](https://docs.arangodb.com/latest/HTTP/Traversal/index.html)

--- a/docs/Drivers/JS/Reference/Collection/EdgeCollection.md
+++ b/docs/Drivers/JS/Reference/Collection/EdgeCollection.md
@@ -50,6 +50,32 @@ if (edge === null) {
 }
 ```
 
+## edgeCollection.documentExists
+
+`async edgeCollection.documentExists(documentHandle): boolean`
+
+Checks whether the edge with the given _documentHandle_ exists.
+
+**Arguments**
+
+- **documentHandle**: `string`
+
+  The handle of the edge to retrieve. This can be either the `_id` or the
+  `_key` of a edge in the collection, or an edge (i.e. an object with an
+  `_id` or `_key` property).
+
+**Examples**
+
+```js
+const db = new Database();
+const collection = db.edgeCollection('my-docs');
+
+const exists = await collection.documentExists('some-key');
+if (exists === false) {
+  // the edge does not exist
+}
+```
+
 ## edgeCollection.save
 
 `async edgeCollection.save(data, [fromId, toId]): Object`

--- a/docs/Drivers/JS/Reference/Graph/EdgeCollection.md
+++ b/docs/Drivers/JS/Reference/Graph/EdgeCollection.md
@@ -11,7 +11,7 @@ Deletes the edge with the given _documentHandle_ from the collection.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the edge to retrieve. This can be either the `_id` or the `_key`
   of an edge in the collection, or an edge (i.e. an object with an `_id` or
@@ -34,17 +34,22 @@ await collection.remove('edges/some-key')
 
 ## graphEdgeCollection.edge
 
-`async graphEdgeCollection.edge(documentHandle): Object`
+`async graphEdgeCollection.edge(documentHandle, [graceful]): Object`
 
 Retrieves the edge with the given _documentHandle_ from the collection.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the edge to retrieve. This can be either the `_id` or the `_key`
   of an edge in the collection, or an edge (i.e. an object with an `_id` or
   `_key` property).
+
+- **graceful**: `boolean` (Default: `false`)
+
+  If set to `true`, the method will return `null` instead of throwing an error
+  if the edge does not exist.
 
 **Examples**
 
@@ -63,6 +68,13 @@ const edge = await collection.edge('edges/some-key');
 // the edge exists
 assert.equal(edge._key, 'some-key');
 assert.equal(edge._id, 'edges/some-key');
+
+// -- or --
+
+const edge = await collection.edge('some-key', true);
+if (edge === null) {
+  // the edge does not exist
+}
 ```
 
 ## graphEdgeCollection.save
@@ -74,18 +86,18 @@ _data_.
 
 **Arguments**
 
-* **data**: `Object`
+- **data**: `Object`
 
   The data of the new edge. If _fromId_ and _toId_ are not specified, the _data_
-  needs to contain the properties __from_ and __to_.
+  needs to contain the properties **from\_ and **to\_.
 
-* **fromId**: `string` (optional)
+- **fromId**: `string` (optional)
 
   The handle of the start vertex of this edge. This can be either the `_id` of a
   document in the database, the `_key` of an edge in the collection, or a
   document (i.e. an object with an `_id` or `_key` property).
 
-* **toId**: `string` (optional)
+- **toId**: `string` (optional)
 
   The handle of the end vertex of this edge. This can be either the `_id` of a
   document in the database, the `_key` of an edge in the collection, or a
@@ -116,7 +128,7 @@ Retrieves a list of all edges of the document with the given _documentHandle_.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve the edges of. This can be either the
   `_id` of a document in the database, the `_key` of an edge in the collection,
@@ -148,7 +160,7 @@ _documentHandle_.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve the edges of. This can be either the
   `_id` of a document in the database, the `_key` of an edge in the collection,
@@ -180,7 +192,7 @@ _documentHandle_.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the document to retrieve the edges of. This can be either the
   `_id` of a document in the database, the `_key` of an edge in the collection,
@@ -212,13 +224,13 @@ contained in this edge collection.
 
 **Arguments**
 
-* **startVertex**: `string`
+- **startVertex**: `string`
 
   The handle of the start vertex. This can be either the `_id` of a document in
   the database, the `_key` of an edge in the collection, or a document (i.e. an
   object with an `_id` or `_key` property).
 
-* **opts**: `Object`
+- **opts**: `Object`
 
   See
   [the HTTP API documentation](https://docs.arangodb.com/latest/HTTP/Traversal/index.html)

--- a/docs/Drivers/JS/Reference/Graph/EdgeCollection.md
+++ b/docs/Drivers/JS/Reference/Graph/EdgeCollection.md
@@ -32,9 +32,11 @@ await collection.remove('edges/some-key')
 // document 'edges/some-key' no longer exists
 ```
 
-## graphEdgeCollection.edge
+## graphEdgeCollection.document
 
-`async graphEdgeCollection.edge(documentHandle, [graceful]): Object`
+`async graphEdgeCollection.document(documentHandle, [graceful]): Object`
+
+Alias: `graphEdgeCollection.edge`.
 
 Retrieves the edge with the given _documentHandle_ from the collection.
 
@@ -57,21 +59,21 @@ Retrieves the edge with the given _documentHandle_ from the collection.
 const graph = db.graph('some-graph');
 const collection = graph.edgeCollection('edges');
 
-const edge = await collection.edge('some-key');
+const edge = await collection.document('some-key');
 // the edge exists
 assert.equal(edge._key, 'some-key');
 assert.equal(edge._id, 'edges/some-key');
 
 // -- or --
 
-const edge = await collection.edge('edges/some-key');
+const edge = await collection.document('edges/some-key');
 // the edge exists
 assert.equal(edge._key, 'some-key');
 assert.equal(edge._id, 'edges/some-key');
 
 // -- or --
 
-const edge = await collection.edge('some-key', true);
+const edge = await collection.document('some-key', true);
 if (edge === null) {
   // the edge does not exist
 }

--- a/docs/Drivers/JS/Reference/Graph/EdgeCollection.md
+++ b/docs/Drivers/JS/Reference/Graph/EdgeCollection.md
@@ -32,6 +32,32 @@ await collection.remove('edges/some-key')
 // document 'edges/some-key' no longer exists
 ```
 
+## graphEdgeCollection.documentExists
+
+`async graphEdgeCollection.documentExists(documentHandle): boolean`
+
+Checks whether the edge with the given _documentHandle_ exists.
+
+**Arguments**
+
+- **documentHandle**: `string`
+
+  The handle of the edge to retrieve. This can be either the `_id` or the
+  `_key` of a edge in the collection, or an edge (i.e. an object with an
+  `_id` or `_key` property).
+
+**Examples**
+
+```js
+const graph = db.graph('some-graph');
+const collection = graph.edgeCollection('edges');
+
+const exists = await collection.documentExists('some-key');
+if (exists === false) {
+  // the edge does not exist
+}
+```
+
 ## graphEdgeCollection.document
 
 `async graphEdgeCollection.document(documentHandle, [graceful]): Object`

--- a/docs/Drivers/JS/Reference/Graph/VertexCollection.md
+++ b/docs/Drivers/JS/Reference/Graph/VertexCollection.md
@@ -11,7 +11,7 @@ Deletes the vertex with the given _documentHandle_ from the collection.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the vertex to retrieve. This can be either the `_id` or the
   `_key` of a vertex in the collection, or a vertex (i.e. an object with an
@@ -34,17 +34,22 @@ await collection.remove('vertices/some-key')
 
 ## graphVertexCollection.vertex
 
-`async graphVertexCollection.vertex(documentHandle): Object`
+`async graphVertexCollection.vertex(documentHandle, [graceful]): Object`
 
 Retrieves the vertex with the given _documentHandle_ from the collection.
 
 **Arguments**
 
-* **documentHandle**: `string`
+- **documentHandle**: `string`
 
   The handle of the vertex to retrieve. This can be either the `_id` or the
   `_key` of a vertex in the collection, or a vertex (i.e. an object with an
   `_id` or `_key` property).
+
+- **graceful**: `boolean` (Default: `false`)
+
+  If set to `true`, the method will return `null` instead of throwing an error
+  if the vertex does not exist.
 
 **Examples**
 
@@ -63,6 +68,13 @@ const doc = await collection.vertex('vertices/some-key');
 // the vertex exists
 assert.equal(doc._key, 'some-key');
 assert.equal(doc._id, 'vertices/some-key');
+
+// -- or --
+
+const doc = await collection.vertex('some-key', true);
+if (doc === null) {
+  // the vertex does not exist
+}
 ```
 
 ## graphVertexCollection.save
@@ -73,7 +85,7 @@ Creates a new vertex with the given _data_.
 
 **Arguments**
 
-* **data**: `Object`
+- **data**: `Object`
 
   The data of the vertex.
 

--- a/docs/Drivers/JS/Reference/Graph/VertexCollection.md
+++ b/docs/Drivers/JS/Reference/Graph/VertexCollection.md
@@ -32,9 +32,11 @@ await collection.remove('vertices/some-key')
 // document 'vertices/some-key' no longer exists
 ```
 
-## graphVertexCollection.vertex
+## graphVertexCollection.document
 
-`async graphVertexCollection.vertex(documentHandle, [graceful]): Object`
+`async graphVertexCollection.document(documentHandle, [graceful]): Object`
+
+Alias: `graphVertexCollection.vertex`.
 
 Retrieves the vertex with the given _documentHandle_ from the collection.
 
@@ -57,14 +59,14 @@ Retrieves the vertex with the given _documentHandle_ from the collection.
 const graph = db.graph('some-graph');
 const collection = graph.vertexCollection('vertices');
 
-const doc = await collection.vertex('some-key');
+const doc = await collection.document('some-key');
 // the vertex exists
 assert.equal(doc._key, 'some-key');
 assert.equal(doc._id, 'vertices/some-key');
 
 // -- or --
 
-const doc = await collection.vertex('vertices/some-key');
+const doc = await collection.document('vertices/some-key');
 // the vertex exists
 assert.equal(doc._key, 'some-key');
 assert.equal(doc._id, 'vertices/some-key');

--- a/docs/Drivers/JS/Reference/Graph/VertexCollection.md
+++ b/docs/Drivers/JS/Reference/Graph/VertexCollection.md
@@ -32,6 +32,32 @@ await collection.remove('vertices/some-key')
 // document 'vertices/some-key' no longer exists
 ```
 
+## graphVertexCollection.documentExists
+
+`async graphVertexCollection.documentExists(documentHandle): boolean`
+
+Checks whether the vertex with the given _documentHandle_ exists.
+
+**Arguments**
+
+- **documentHandle**: `string`
+
+  The handle of the vertex to retrieve. This can be either the `_id` or the
+  `_key` of a vertex in the collection, or a vertex (i.e. an object with an
+  `_id` or `_key` property).
+
+**Examples**
+
+```js
+const graph = db.graph('some-graph');
+const collection = graph.vertexCollection('vertices');
+
+const exists = await collection.documentExists('some-key');
+if (exists === false) {
+  // the vertex does not exist
+}
+```
+
 ## graphVertexCollection.document
 
 `async graphVertexCollection.document(documentHandle, [graceful]): Object`

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,5 +1,6 @@
 import { Connection } from "./connection";
 import { ArrayCursor } from "./cursor";
+import { isArangoError } from "./error";
 
 export enum CollectionType {
   DOCUMENT_COLLECTION = 2,
@@ -30,7 +31,8 @@ export interface ArangoCollection {
   name: string;
 }
 
-const COLLECTION_NOT_FOUND = 1203;
+export const DOCUMENT_NOT_FOUND = 1202;
+export const COLLECTION_NOT_FOUND = 1203;
 export abstract class BaseCollection implements ArangoCollection {
   isArangoCollection: true = true;
   name: string;
@@ -109,10 +111,10 @@ export abstract class BaseCollection implements ArangoCollection {
     return this.get().then(
       () => true,
       err => {
-        if (err.errorNum !== COLLECTION_NOT_FOUND) {
-          throw err;
+        if (isArangoError(err) && err.errorNum === COLLECTION_NOT_FOUND) {
+          return false;
         }
-        return false;
+        throw err;
       }
     );
   }
@@ -649,11 +651,21 @@ export class DocumentCollection extends BaseCollection {
     return `/document/${this._documentHandle(documentHandle)}`;
   }
 
-  document(documentHandle: DocumentHandle) {
-    return this._connection.request(
+  document(
+    documentHandle: DocumentHandle,
+    graceful: boolean = false
+  ): Promise<any> {
+    const result = this._connection.request(
       { path: `/_api/${this._documentPath(documentHandle)}` },
       res => res.body
     );
+    if (!graceful) return result;
+    return result.catch(err => {
+      if (isArangoError(err) && err.errorNum === DOCUMENT_NOT_FOUND) {
+        return null;
+      }
+      throw err;
+    });
   }
 
   save(data: any, opts?: DocumentSaveOptions | boolean) {
@@ -702,11 +714,21 @@ export class EdgeCollection extends BaseCollection {
     return `document/${this._documentHandle(documentHandle)}`;
   }
 
-  edge(documentHandle: DocumentHandle) {
-    return this._connection.request(
+  edge(
+    documentHandle: DocumentHandle,
+    graceful: boolean = false
+  ): Promise<any> {
+    const result = this._connection.request(
       { path: `/_api/${this._documentPath(documentHandle)}` },
       res => res.body
     );
+    if (!graceful) return result;
+    return result.catch(err => {
+      if (isArangoError(err) && err.errorNum === DOCUMENT_NOT_FOUND) {
+        return null;
+      }
+      throw err;
+    });
   }
 
   save(data: any, opts?: DocumentSaveOptions | boolean): Promise<any>;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -51,7 +51,9 @@ export abstract class BaseCollection implements ArangoCollection {
     }
   }
 
-  protected abstract _documentPath(documentHandle: DocumentHandle): string;
+  protected _documentPath(documentHandle: DocumentHandle) {
+    return `/document/${this._documentHandle(documentHandle)}`;
+  }
 
   protected _documentHandle(documentHandle: DocumentHandle) {
     if (typeof documentHandle !== "string") {
@@ -662,10 +664,6 @@ export class DocumentCollection extends BaseCollection {
   type = CollectionType.DOCUMENT_COLLECTION;
   constructor(connection: Connection, name: string) {
     super(connection, name);
-  }
-
-  protected _documentPath(documentHandle: DocumentHandle) {
-    return `/document/${this._documentHandle(documentHandle)}`;
   }
 
   save(data: any, opts?: DocumentSaveOptions | boolean) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -202,6 +202,23 @@ export abstract class BaseCollection implements ArangoCollection {
     );
   }
 
+  document(
+    documentHandle: DocumentHandle,
+    graceful: boolean = false
+  ): Promise<any> {
+    const result = this._connection.request(
+      { path: `/_api/${this._documentPath(documentHandle)}` },
+      res => res.body
+    );
+    if (!graceful) return result;
+    return result.catch(err => {
+      if (isArangoError(err) && err.errorNum === DOCUMENT_NOT_FOUND) {
+        return null;
+      }
+      throw err;
+    });
+  }
+
   replace(documentHandle: DocumentHandle, newValue: any, opts: any = {}) {
     const headers: { [key: string]: string } = {};
     if (typeof opts === "string") {
@@ -651,23 +668,6 @@ export class DocumentCollection extends BaseCollection {
     return `/document/${this._documentHandle(documentHandle)}`;
   }
 
-  document(
-    documentHandle: DocumentHandle,
-    graceful: boolean = false
-  ): Promise<any> {
-    const result = this._connection.request(
-      { path: `/_api/${this._documentPath(documentHandle)}` },
-      res => res.body
-    );
-    if (!graceful) return result;
-    return result.catch(err => {
-      if (isArangoError(err) && err.errorNum === DOCUMENT_NOT_FOUND) {
-        return null;
-      }
-      throw err;
-    });
-  }
-
   save(data: any, opts?: DocumentSaveOptions | boolean) {
     if (typeof opts === "boolean") {
       opts = { returnNew: opts };
@@ -718,17 +718,7 @@ export class EdgeCollection extends BaseCollection {
     documentHandle: DocumentHandle,
     graceful: boolean = false
   ): Promise<any> {
-    const result = this._connection.request(
-      { path: `/_api/${this._documentPath(documentHandle)}` },
-      res => res.body
-    );
-    if (!graceful) return result;
-    return result.catch(err => {
-      if (isArangoError(err) && err.errorNum === DOCUMENT_NOT_FOUND) {
-        return null;
-      }
-      throw err;
-    });
+    return this.document(documentHandle, graceful);
   }
 
   save(data: any, opts?: DocumentSaveOptions | boolean): Promise<any>;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -204,6 +204,23 @@ export abstract class BaseCollection implements ArangoCollection {
     );
   }
 
+  documentExists(documentHandle: DocumentHandle): Promise<boolean> {
+    return this._connection
+      .request(
+        {
+          method: "HEAD",
+          path: `/_api/${this._documentPath(documentHandle)}`
+        },
+        () => true
+      )
+      .catch(err => {
+        if (err.statusCode === 404) {
+          return false;
+        }
+        throw err;
+      });
+  }
+
   document(
     documentHandle: DocumentHandle,
     graceful: boolean = false

--- a/src/database.ts
+++ b/src/database.ts
@@ -8,6 +8,7 @@ import {
 } from "./collection";
 import { Config, Connection } from "./connection";
 import { ArrayCursor } from "./cursor";
+import { isArangoError } from "./error";
 import { Graph } from "./graph";
 import { Route } from "./route";
 import { btoa } from "./util/btoa";
@@ -112,10 +113,10 @@ export class Database {
     return this.get().then(
       () => true,
       err => {
-        if (err.errorNum !== DATABASE_NOT_FOUND) {
-          throw err;
+        if (isArangoError(err) && err.errorNum === DATABASE_NOT_FOUND) {
+          return false;
         }
-        return false;
+        throw err;
       }
     );
   }

--- a/src/error.ts
+++ b/src/error.ts
@@ -55,6 +55,10 @@ const nativeErrorKeys = [
   "number"
 ] as (keyof Error)[];
 
+export function isArangoError(err: any): err is ArangoError {
+  return Boolean(err && err.isArangoError);
+}
+
 export class ArangoError extends ExtendableError {
   name = "ArangoError";
   isArangoError = true;

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -20,10 +20,6 @@ export class GraphVertexCollection extends BaseCollection {
     this.graph = graph;
   }
 
-  protected _documentPath(documentHandle: DocumentHandle) {
-    return `/document/${this._documentHandle(documentHandle)}`;
-  }
-
   document(
     documentHandle: DocumentHandle,
     graceful: boolean = false

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -24,7 +24,7 @@ export class GraphVertexCollection extends BaseCollection {
     return `/document/${this._documentHandle(documentHandle)}`;
   }
 
-  vertex(
+  document(
     documentHandle: DocumentHandle,
     graceful: boolean = false
   ): Promise<any> {
@@ -43,6 +43,13 @@ export class GraphVertexCollection extends BaseCollection {
       }
       throw err;
     });
+  }
+
+  vertex(
+    documentHandle: DocumentHandle,
+    graceful: boolean = false
+  ): Promise<any> {
+    return this.document(documentHandle, graceful);
   }
 
   save(data: any, opts?: { waitForSync?: boolean }) {
@@ -140,7 +147,7 @@ export class GraphEdgeCollection extends EdgeCollection {
     this.graph = graph;
   }
 
-  edge(
+  document(
     documentHandle: DocumentHandle,
     graceful: boolean = false
   ): Promise<any> {

--- a/src/test/14-document-collections.ts
+++ b/src/test/14-document-collections.ts
@@ -66,6 +66,10 @@ describe("DocumentCollection API", function() {
         .then(() => void done())
         .catch(done);
     });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.document("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
   });
   describe("documentCollection.save", () => {
     it("creates a document in the collection", done => {

--- a/src/test/14-document-collections.ts
+++ b/src/test/14-document-collections.ts
@@ -44,27 +44,16 @@ describe("DocumentCollection API", function() {
   describe("documentCollection.document", () => {
     let data = { foo: "bar" };
     let meta: any;
-    beforeEach(done => {
-      collection
-        .save(data)
-        .then(result => {
-          meta = result;
-          done();
-        })
-        .catch(done);
+    beforeEach(async () => {
+      meta = await collection.save(data);
     });
-    it("returns a document in the collection", done => {
-      collection
-        .document(meta._id)
-        .then(doc => {
-          expect(doc).to.have.keys("_key", "_id", "_rev", "foo");
-          expect(doc._id).to.equal(meta._id);
-          expect(doc._key).to.equal(meta._key);
-          expect(doc._rev).to.equal(meta._rev);
-          expect(doc.foo).to.equal(data.foo);
-        })
-        .then(() => void done())
-        .catch(done);
+    it("returns a document in the collection", async () => {
+      const doc = await collection.document(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "foo");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc.foo).to.equal(data.foo);
     });
     it("does not throw on not found when graceful", async () => {
       const doc = await collection.document("does-not-exist", true);

--- a/src/test/14-document-collections.ts
+++ b/src/test/14-document-collections.ts
@@ -60,6 +60,27 @@ describe("DocumentCollection API", function() {
       expect(doc).to.equal(null);
     });
   });
+  describe("documentCollection.documentExists", () => {
+    let data = { foo: "bar" };
+    let meta: any;
+    beforeEach(async () => {
+      meta = await collection.save(data);
+    });
+    it("returns true if the document exists", async () => {
+      const exists = await collection.documentExists(meta._id);
+      expect(exists).to.equal(true);
+    });
+    it("returns false if the document does not exist", async () => {
+      const exists = await collection.documentExists("does-not-exist");
+      expect(exists).to.equal(false);
+    });
+    it("returns false if the collection does not exist", async () => {
+      const exists = await db
+        .collection("does-not-exist")
+        .documentExists("lol");
+      expect(exists).to.equal(false);
+    });
+  });
   describe("documentCollection.save", () => {
     it("creates a document in the collection", done => {
       let data = { foo: "bar" };

--- a/src/test/15-edge-collections.ts
+++ b/src/test/15-edge-collections.ts
@@ -65,6 +65,10 @@ describe("EdgeCollection API", function() {
         .then(() => void done())
         .catch(done);
     });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.edge("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
   });
   describe("edgeCollection.save", () => {
     it("creates an edge in the collection", done => {

--- a/src/test/15-edge-collections.ts
+++ b/src/test/15-edge-collections.ts
@@ -42,32 +42,56 @@ describe("EdgeCollection API", function() {
   describe("edgeCollection.edge", () => {
     let data = { _from: "d/1", _to: "d/2" };
     let meta: any;
-    beforeEach(done => {
-      collection
-        .save(data)
-        .then(result => {
-          meta = result;
-          done();
-        })
-        .catch(done);
+    beforeEach(async () => {
+      meta = await collection.save(data);
     });
-    it("returns an edge in the collection", done => {
-      collection
-        .edge(meta._id)
-        .then(doc => {
-          expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
-          expect(doc._id).to.equal(meta._id);
-          expect(doc._key).to.equal(meta._key);
-          expect(doc._rev).to.equal(meta._rev);
-          expect(doc._from).to.equal(data._from);
-          expect(doc._to).to.equal(data._to);
-        })
-        .then(() => void done())
-        .catch(done);
+    it("returns an edge in the collection", async () => {
+      const doc = await collection.edge(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc._from).to.equal(data._from);
+      expect(doc._to).to.equal(data._to);
     });
     it("does not throw on not found when graceful", async () => {
       const doc = await collection.edge("does-not-exist", true);
       expect(doc).to.equal(null);
+    });
+  });
+  describe("edgeCollection.document", () => {
+    let data = { _from: "d/1", _to: "d/2" };
+    let meta: any;
+    beforeEach(async () => {
+      meta = await collection.save(data);
+    });
+    it("returns an edge in the collection", async () => {
+      const doc = await collection.document(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc._from).to.equal(data._from);
+      expect(doc._to).to.equal(data._to);
+    });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.document("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
+  });
+  describe("edgeCollection.documentExists", () => {
+    let data = { _from: "d/1", _to: "d/2" };
+    let meta: any;
+    beforeEach(async () => {
+      meta = await collection.save(data);
+    });
+    it("returns true if the edge exists", async () => {
+      const exists = await collection.documentExists(meta._id);
+      expect(exists).to.equal(true);
+    });
+    it("returns false if the edge does not exist", async () => {
+      const exists = await collection.documentExists("does-not-exist");
+      expect(exists).to.equal(false);
     });
   });
   describe("edgeCollection.save", () => {

--- a/src/test/19-graph-vertex-collections.ts
+++ b/src/test/19-graph-vertex-collections.ts
@@ -67,6 +67,10 @@ describe("GraphVertexCollection API", function() {
         .then(() => void done())
         .catch(done);
     });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.vertex("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
   });
   describe("graphVertexCollection.save", () => {
     it("creates a vertex in the collection", done => {

--- a/src/test/19-graph-vertex-collections.ts
+++ b/src/test/19-graph-vertex-collections.ts
@@ -45,30 +45,38 @@ describe("GraphVertexCollection API", function() {
   describe("graphVertexCollection.vertex", () => {
     let data = { foo: "bar" };
     let meta: any;
-    beforeEach(done => {
-      collection
-        .save(data)
-        .then(result => {
-          meta = result;
-          done();
-        })
-        .catch(done);
+    beforeEach(async () => {
+      meta = await collection.save(data);
     });
-    it("returns a vertex in the collection", done => {
-      collection
-        .vertex(meta._id)
-        .then(doc => {
-          expect(doc).to.have.keys("_key", "_id", "_rev", "foo");
-          expect(doc._id).to.equal(meta._id);
-          expect(doc._key).to.equal(meta._key);
-          expect(doc._rev).to.equal(meta._rev);
-          expect(doc.foo).to.equal(data.foo);
-        })
-        .then(() => void done())
-        .catch(done);
+    it("returns a vertex in the collection", async () => {
+      const doc = await collection.vertex(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "foo");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc.foo).to.equal(data.foo);
     });
     it("does not throw on not found when graceful", async () => {
       const doc = await collection.vertex("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
+  });
+  describe("graphVertexCollection.document", () => {
+    let data = { foo: "bar" };
+    let meta: any;
+    beforeEach(async () => {
+      meta = await collection.save(data);
+    });
+    it("returns a vertex in the collection", async () => {
+      const doc = await collection.document(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "foo");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc.foo).to.equal(data.foo);
+    });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.document("does-not-exist", true);
       expect(doc).to.equal(null);
     });
   });

--- a/src/test/20-graph-edge-collections.ts
+++ b/src/test/20-graph-edge-collections.ts
@@ -8,7 +8,7 @@ describe("GraphEdgeCollection API", function() {
 
   const dbName = `testdb_${Date.now()}`;
   let db: Database;
-  let edge: GraphEdgeCollection;
+  let collection: GraphEdgeCollection;
   before(async () => {
     db = new Database({
       url: process.env.TEST_ARANGODB_URL || "http://localhost:8529",
@@ -26,7 +26,7 @@ describe("GraphEdgeCollection API", function() {
         }
       ]
     });
-    edge = graph.edgeCollection("knows");
+    collection = graph.edgeCollection("knows");
     await graph
       .vertexCollection("person")
       .import([
@@ -46,7 +46,7 @@ describe("GraphEdgeCollection API", function() {
     }
   });
   beforeEach(done => {
-    edge
+    collection
       .truncate()
       .then(() => done())
       .catch(done);
@@ -55,7 +55,7 @@ describe("GraphEdgeCollection API", function() {
     let data = { _from: "person/Bob", _to: "person/Alice" };
     let meta: any;
     beforeEach(done => {
-      edge
+      collection
         .save(data)
         .then(result => {
           meta = result;
@@ -64,7 +64,7 @@ describe("GraphEdgeCollection API", function() {
         .catch(done);
     });
     it("returns an edge in the collection", done => {
-      edge
+      collection
         .edge(meta._id)
         .then(doc => {
           expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
@@ -77,11 +77,15 @@ describe("GraphEdgeCollection API", function() {
         .then(() => void done())
         .catch(done);
     });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.edge("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
   });
   describe("edgeCollection.save", () => {
     it("creates an edge in the collection", done => {
       let data = { _from: "person/Bob", _to: "person/Alice" };
-      edge
+      collection
         .save(data)
         .then(meta => {
           expect(meta).to.be.an("object");
@@ -94,7 +98,7 @@ describe("GraphEdgeCollection API", function() {
           expect(meta)
             .to.have.property("_key")
             .that.is.a("string");
-          return edge.edge(meta._id).then(doc => {
+          return collection.edge(meta._id).then(doc => {
             expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
             expect(doc._id).to.equal(meta._id);
             expect(doc._key).to.equal(meta._key);
@@ -108,7 +112,7 @@ describe("GraphEdgeCollection API", function() {
     });
     it("uses the given _key if provided", done => {
       let data = { _key: "banana", _from: "person/Bob", _to: "person/Alice" };
-      edge
+      collection
         .save(data)
         .then(meta => {
           expect(meta).to.be.an("object");
@@ -121,7 +125,7 @@ describe("GraphEdgeCollection API", function() {
           expect(meta)
             .to.have.property("_key")
             .that.equals(data._key);
-          return edge.edge(meta._id).then(doc => {
+          return collection.edge(meta._id).then(doc => {
             expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
             expect(doc._id).to.equal(meta._id);
             expect(doc._rev).to.equal(meta._rev);
@@ -136,7 +140,7 @@ describe("GraphEdgeCollection API", function() {
   });
   describe("edgeCollection.traversal", () => {
     beforeEach(done => {
-      edge
+      collection
         .import([
           { _from: "person/Alice", _to: "person/Bob" },
           { _from: "person/Bob", _to: "person/Charlie" },
@@ -148,7 +152,7 @@ describe("GraphEdgeCollection API", function() {
         .catch(done);
     });
     it("executes traversal", done => {
-      edge
+      collection
         .traversal("person/Alice", { direction: "outbound" })
         .then((result: any) => {
           expect(result).to.have.property("visited");
@@ -177,18 +181,18 @@ describe("GraphEdgeCollection API", function() {
         _from: "person/Bob",
         _to: "person/Alice"
       };
-      edge
+      collection
         .save(doc)
         .then(meta => {
           delete meta.error;
           Object.assign(doc, meta);
-          return edge.replace(doc as any, {
+          return collection.replace(doc as any, {
             sup: "dawg",
             _from: "person/Bob",
             _to: "person/Alice"
           });
         })
-        .then(() => edge.edge((doc as any)._key))
+        .then(() => collection.edge((doc as any)._key))
         .then(data => {
           expect(data).not.to.have.property("potato");
           expect(data).to.have.property("sup", "dawg");
@@ -205,14 +209,14 @@ describe("GraphEdgeCollection API", function() {
         _from: "person/Bob",
         _to: "person/Alice"
       };
-      edge
+      collection
         .save(doc)
         .then(meta => {
           delete meta.error;
           Object.assign(doc, meta);
-          return edge.update(doc as any, { sup: "dawg", empty: null });
+          return collection.update(doc as any, { sup: "dawg", empty: null });
         })
-        .then(() => edge.edge((doc as any)._key))
+        .then(() => collection.edge((doc as any)._key))
         .then(data => {
           expect(data).to.have.property("potato", doc.potato);
           expect(data).to.have.property("sup", "dawg");
@@ -228,18 +232,18 @@ describe("GraphEdgeCollection API", function() {
         _from: "person/Bob",
         _to: "person/Alice"
       };
-      edge
+      collection
         .save(doc)
         .then(meta => {
           delete meta.error;
           Object.assign(doc, meta);
-          return edge.update(
+          return collection.update(
             doc as any,
             { sup: "dawg", empty: null },
             { keepNull: false }
           );
         })
-        .then(() => edge.edge((doc as any)._key))
+        .then(() => collection.edge((doc as any)._key))
         .then(data => {
           expect(data).to.have.property("potato", doc.potato);
           expect(data).to.have.property("sup", "dawg");
@@ -252,15 +256,15 @@ describe("GraphEdgeCollection API", function() {
   describe("edgeCollection.remove", () => {
     let key = `d_${Date.now()}`;
     beforeEach(done => {
-      edge
+      collection
         .save({ _key: key, _from: "person/Bob", _to: "person/Alice" })
         .then(() => void done())
         .catch(done);
     });
     it("deletes the given edge", done => {
-      edge
+      collection
         .remove(key)
-        .then(() => edge.edge(key))
+        .then(() => collection.edge(key))
         .then(
           () => Promise.reject(new Error("Should not succeed")),
           () => void done()

--- a/src/test/20-graph-edge-collections.ts
+++ b/src/test/20-graph-edge-collections.ts
@@ -54,31 +54,40 @@ describe("GraphEdgeCollection API", function() {
   describe("edgeCollection.edge", () => {
     let data = { _from: "person/Bob", _to: "person/Alice" };
     let meta: any;
-    beforeEach(done => {
-      collection
-        .save(data)
-        .then(result => {
-          meta = result;
-          done();
-        })
-        .catch(done);
+    beforeEach(async () => {
+      meta = await collection.save(data);
     });
-    it("returns an edge in the collection", done => {
-      collection
-        .edge(meta._id)
-        .then(doc => {
-          expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
-          expect(doc._id).to.equal(meta._id);
-          expect(doc._key).to.equal(meta._key);
-          expect(doc._rev).to.equal(meta._rev);
-          expect(doc._from).to.equal(data._from);
-          expect(doc._to).to.equal(data._to);
-        })
-        .then(() => void done())
-        .catch(done);
+    it("returns an edge in the collection", async () => {
+      const doc = await collection.edge(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc._from).to.equal(data._from);
+      expect(doc._to).to.equal(data._to);
     });
     it("does not throw on not found when graceful", async () => {
       const doc = await collection.edge("does-not-exist", true);
+      expect(doc).to.equal(null);
+    });
+  });
+  describe("edgeCollection.document", () => {
+    let data = { _from: "person/Bob", _to: "person/Alice" };
+    let meta: any;
+    beforeEach(async () => {
+      meta = await collection.save(data);
+    });
+    it("returns an edge in the collection", async () => {
+      const doc = await collection.document(meta._id);
+      expect(doc).to.have.keys("_key", "_id", "_rev", "_from", "_to");
+      expect(doc._id).to.equal(meta._id);
+      expect(doc._key).to.equal(meta._key);
+      expect(doc._rev).to.equal(meta._rev);
+      expect(doc._from).to.equal(data._from);
+      expect(doc._to).to.equal(data._to);
+    });
+    it("does not throw on not found when graceful", async () => {
+      const doc = await collection.document("does-not-exist", true);
       expect(doc).to.equal(null);
     });
   });

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,4 +1,5 @@
 import { Connection } from "./connection";
+import { isArangoError } from "./error";
 
 export enum ViewType {
   ARANGOSEARCH_VIEW = "arangosearch"
@@ -93,10 +94,10 @@ export abstract class BaseView implements ArangoView {
     return this.get().then(
       () => true,
       err => {
-        if (err.errorNum !== VIEW_NOT_FOUND) {
-          throw err;
+        if (isArangoError(err) && err.errorNum === VIEW_NOT_FOUND) {
+          return false;
         }
-        return false;
+        throw err;
       }
     );
   }


### PR DESCRIPTION
This PR adds a `graceful` flag to the collections' document/edge/vertex methods, allowing users to check if a document exists without needing to explicitly handle `DOCUMENT_NOT_FOUND` errors (`null` will be returned instead).

This is a compromise towards adding an explicit `documentExists` method that would silently discard the response body and thus hide the cost of fetching the entire document. In lieu of an existence endpoint in the HTTP API (or support for the `HEAD` method), this seems like the next best thing.

/cc  @Gby56 and @Vincz who have requested a `documentExists` method before.