### PR TITLE
Docs: Fix BulkImport link and code example

### DIFF
--- a/docs/Drivers/JS/Reference/Collection/BulkImport.md
+++ b/docs/Drivers/JS/Reference/Collection/BulkImport.md
@@ -105,8 +105,8 @@ Bulk imports the given _data_ into the collection.
     Whether the response should contain additional details about documents that
     could not be imported.
 
-For more information on the _opts_ object, see
-[the HTTP API documentation for bulk imports](https://docs.arangodb.com/latest/HTTP/BulkImports/).
+For more information on the _opts_ object, see the
+[HTTP API documentation for bulk imports](https://docs.arangodb.com/latest/HTTP/BulkImports/index.html).
 
 **Examples**
 
@@ -135,16 +135,16 @@ const result = await collection.import(
   buf,
   { type: "array" } // optional
 );
-```
 
 // -- or --
 
 const result = await collection.import(
-[
-["username", "password"],
-["jcd", "bionicman"],
-["jreyes", "amigo"],
-["ghermann", "zeitgeist"]
-],
-{ type: null } // required
+  [
+    ["username", "password"],
+    ["jcd", "bionicman"],
+    ["jreyes", "amigo"],
+    ["ghermann", "zeitgeist"]
+  ],
+  { type: null } // required
 );
+```


### PR DESCRIPTION
The external link is converted to a relative link in documentation building, and there you must always refer to a file.
`BulkImports/README.md` becomes `BulkImports/index.html` and is the file you get to see online for `BulkImports/`