### PR TITLE
Fix reflective Foxx tests for sockets

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,6 +6,7 @@ import {
   isBrowser,
   RequestFunction
 } from "./util/request";
+import { sanitizeUrl } from "./util/sanitizeUrl";
 
 const LinkedList = require("linkedlist/lib/linkedlist") as typeof Array;
 
@@ -225,17 +226,9 @@ export class Connection {
     return search ? { pathname, search } : { pathname };
   }
 
-  private _sanitizeEndpointUrl(url: string): string {
-    const raw = url.match(/^(tcp|ssl|tls)((?::|\+).+)/);
-    if (raw) url = (raw[1] === "tcp" ? "http" : "https") + raw[2];
-    const unix = url.match(/^(?:(https?)\+)?unix:\/\/(\/.+)/);
-    if (unix) url = `${unix[1] || "http"}://unix:${unix[2]}`;
-    return url;
-  }
-
   addToHostList(urls: string | string[]): number[] {
     const cleanUrls = (Array.isArray(urls) ? urls : [urls]).map(url =>
-      this._sanitizeEndpointUrl(url)
+      sanitizeUrl(url)
     );
     const newUrls = cleanUrls.filter(url => this._urls.indexOf(url) === -1);
     this._urls.push(...newUrls);

--- a/src/util/sanitizeUrl.ts
+++ b/src/util/sanitizeUrl.ts
@@ -1,0 +1,7 @@
+export function sanitizeUrl(url: string): string {
+  const raw = url.match(/^(tcp|ssl|tls)((?::|\+).+)/);
+  if (raw) url = (raw[1] === "tcp" ? "http" : "https") + raw[2];
+  const unix = url.match(/^(?:(https?)\+)?unix:\/\/(\/.+)/);
+  if (unix) url = `${unix[1] || "http"}://unix:${unix[2]}`;
+  return url;
+}


### PR DESCRIPTION
This fixes the Foxx tests that currently fail in socket mode but requires https://github.com/arangodb/arangodb/pull/7327 to have been merged.