### PR TITLE
Fix assignment response.host to task.host

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -205,7 +205,7 @@ export class Connection {
           }
           this._queue.push(task);
         } else {
-          response.host = host;
+          task.host = host;
           task.resolve(response);
         }
       }


### PR DESCRIPTION
The assignment to response.host throws an error because host is a getter. This looks to be a typo given everywhere else the assignment is to task.host. Before the fix, the error thrown was:

TypeError: Cannot set property host of #<IncomingMessage> which has only a getter
    at _hosts.(anonymous function) (/Users/rob/Projects/RobOnCode/totaljs-example/node_modules/arangojs/lib/async/connection.js:130:35)
    at IncomingMessage.res.on (/Users/rob/Projects/RobOnCode/totaljs-example/node_modules/arangojs/lib/async/util/request.node.js:78:21)
    at IncomingMessage.emit (events.js:185:15)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
