### PR TITLE
Pass on query timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- The `timeout` options in `db.query` is now passed on to the server
+
+  Arangojs will still cancel the query on the client-side when the request timeout is reached, but this allows
+  ArangoDB to independently kill the query if it doesn't execute in time.
+
 ### Fixed
 
 - Replaced `linkedlist` dependency with `x3-linkedlist` ([#601](https://github.com/arangodb/arangojs/issues/601))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- The `timeout` option in `db.query` is now passed on to the server
+
+  Arangojs will still cancel the query on the client-side when the request timeout is reached, but this allows
+  ArangoDB to independently kill the query if it doesn't execute in time. Note that if `clientTimeout` is set,
+  the `timeout` option will be interpreted as seconds like ArangoDB expects whereas if `clientTimeout` is
+  omitted, the `timeout` value will be converted from milliseconds for backwards compatibility.
+  
+  Setting `clientTimeout` to zero disables the client-side timeout while resulting in `timeout` being treated
+  as a seconds value query option that will be passed on to ArangoDB unmodified.
+
 ### Added
 
 - Added `clientTimeout` option to `db.query`
@@ -15,13 +27,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   i.e. it will result in the request being cancelled after the timeout is reached but the value will not be
   sent to the server as a query option. If both `clientTimeout` and `timeout` are specified, `clientTimeout`
   will be used to determine when the request should be cancelled and `timeout` will be sent to the server.
-
-### Changed
-
-- The `timeout` option in `db.query` is now passed on to the server
-
-  Arangojs will still cancel the query on the client-side when the request timeout is reached, but this allows
-  ArangoDB to independently kill the query if it doesn't execute in time.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `clientTimeout` option to `db.query`
+
+  The behavior of `clientTimeout` is identical to the behavior of `timeout` in previous versions of arangojs,
+  i.e. it will result in the request being cancelled after the timeout is reached but the value will not be
+  sent to the server as a query option. If both `clientTimeout` and `timeout` are specified, `clientTimeout`
+  will be used to determine when the request should be cancelled and `timeout` will be sent to the server.
+
 ### Changed
 
-- The `timeout` options in `db.query` is now passed on to the server
+- The `timeout` option in `db.query` is now passed on to the server
 
   Arangojs will still cancel the query on the client-side when the request timeout is reached, but this allows
   ArangoDB to independently kill the query if it doesn't execute in time.

--- a/docs/Drivers/JS/Reference/Database/Queries.md
+++ b/docs/Drivers/JS/Reference/Database/Queries.md
@@ -54,9 +54,11 @@ versions of ArangoDB.
 
 Additionally _opts.timeout_ can be set to a non-negative number to force the
 request to be cancelled after that amount of milliseconds. Note that this will
-simply close the connection and not result in the actual query being cancelled
-in ArangoDB, the query will still be executed to completion and continue to
-consume resources in the database or cluster.
+simply close the connection and cancel the request on the client-side.
+
+Note that this value must be specified in milliseconds. As versions of ArangoDB that
+support this option expect it to be specified in seconds, the value will be converted
+automatically before sending it to the server.
 
 If _query_ is an object with _query_ and _bindVars_ properties, those will be
 used as the values of the respective arguments instead.

--- a/docs/Drivers/JS/Reference/Database/Queries.md
+++ b/docs/Drivers/JS/Reference/Database/Queries.md
@@ -52,9 +52,16 @@ Dirty reads were introduced in ArangoDB 3.4 and are not supported by earlier
 versions of ArangoDB.
 {% endhint %}
 
-Additionally _opts.timeout_ can be set to a non-negative number to force the
+Additionally _opts.clientTimeout_ can be set to a non-negative number to force the
 request to be cancelled after that amount of milliseconds. Note that this will
 simply close the connection and cancel the request on the client-side.
+
+{% hint 'warning' %}
+Note that for historical reasons if _opts.clientTimeout_ is not set, the value of
+_opts.timeout_ must be specified in milliseconds and will additionally behave like
+_opts.clientTimeout_. To set _opts.timeout_ in seconds without using a client-side
+timeout, you can set _opts.clientTimeout_ to `0`.
+{% endhint %}
 
 Note that this value must be specified in milliseconds. As versions of ArangoDB that
 support this option expect it to be specified in seconds, the value will be converted

--- a/src/database.ts
+++ b/src/database.ts
@@ -504,7 +504,7 @@ export class Database {
       {
         method: "POST",
         path: "/_api/cursor",
-        body: { ...extra, query, bindVars, timeout },
+        body: { ...extra, query, bindVars, timeout: timeout ? Math.ceil(timeout / 1000) : undefined },
         allowDirtyRead,
         timeout
       },

--- a/src/database.ts
+++ b/src/database.ts
@@ -504,7 +504,7 @@ export class Database {
       {
         method: "POST",
         path: "/_api/cursor",
-        body: { ...extra, query, bindVars },
+        body: { ...extra, query, bindVars, timeout },
         allowDirtyRead,
         timeout
       },

--- a/src/database.ts
+++ b/src/database.ts
@@ -63,6 +63,7 @@ export type QueryOptions = {
   cache?: boolean;
   memoryLimit?: number;
   ttl?: number;
+  clientTimeout?: number;
   timeout?: number;
   options?: {
     failOnWarning?: boolean;
@@ -498,7 +499,7 @@ export class Database {
     } else if (isAqlLiteral(query)) {
       query = query.toAQL();
     }
-    const { allowDirtyRead = undefined, timeout = undefined, ...extra } =
+    const { allowDirtyRead = undefined, timeout = undefined, clientTimeout = undefined, ...extra } =
       opts || {};
     return this._connection.request(
       {
@@ -506,7 +507,7 @@ export class Database {
         path: "/_api/cursor",
         body: { ...extra, query, bindVars, timeout: timeout ? Math.ceil(timeout / 1000) : undefined },
         allowDirtyRead,
-        timeout
+        timeout: clientTimeout === undefined ? timeout : clientTimeout
       },
       res =>
         new ArrayCursor(

--- a/src/database.ts
+++ b/src/database.ts
@@ -505,7 +505,12 @@ export class Database {
       {
         method: "POST",
         path: "/_api/cursor",
-        body: { ...extra, query, bindVars, timeout: timeout ? Math.ceil(timeout / 1000) : undefined },
+        body: {
+          ...extra,
+          query,
+          bindVars,
+          timeout: (clientTimeout === undefined && timeout) ? Math.ceil(timeout / 1000) : timeout
+        },
         allowDirtyRead,
         timeout: clientTimeout === undefined ? timeout : clientTimeout
       },


### PR DESCRIPTION
This changes the behavior of the `timeout` option.

As ArangoDB expects the value be specified in seconds whereas arangojs used an option with the same name but specified in milliseconds, this change is a bit clunky to maintain backwards compatibility:

The old `timeout` option is now called `clientTimeout`. Setting this option to zero means no client-side timeout will be set.

If `clientTimeout` is set to a number (even if it is set to zero), `timeout` (as seconds) will be passed on to ArangoDB as expected by newer releases of ArangoDB.

If `clientTimeout` is undefined, `timeout` will be used for the client-side timeout (as milliseconds) and additionally passed on to ArangoDB (but converted to seconds).

Old code will continue working as before except the `timeout` value will be additionally converted from milliseconds to seconds (i.e. divided by 1000) and sent as a query option.

New code should use `clientTimeout` if any timeout is desired (even if `clientTimeout` is set to zero) and set the `timeout` in seconds.