### PR TITLE
Deprecations for v6

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -194,7 +194,12 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
-  properties(): Promise<CollectionProperties> {
+  properties(
+    properties?: CollectionPropertiesOptions
+  ): Promise<CollectionProperties> {
+    if (properties) {
+      return this._put("properties", properties);
+    }
     return this._get("properties");
   }
 
@@ -225,6 +230,10 @@ export abstract class BaseCollection<T extends object = any>
     return this._put("unload", undefined);
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.properties} instead.
+   */
   setProperties(properties: CollectionPropertiesOptions) {
     return this._put("properties", properties);
   }
@@ -645,7 +654,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
-  /** @deprecated use ensureIndex instead */
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createIndex(details: any) {
     return this.ensureIndex(details);
   }
@@ -660,6 +672,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createCapConstraint(opts?: any) {
     if (typeof opts === "number") {
       opts = { size: opts };
@@ -675,6 +691,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createHashIndex(fields: string[] | string, opts?: any) {
     if (typeof fields === "string") {
       fields = [fields];
@@ -693,6 +713,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createSkipList(fields: string[] | string, opts?: any) {
     if (typeof fields === "string") {
       fields = [fields];
@@ -711,6 +735,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createPersistentIndex(fields: string[] | string, opts?: any) {
     if (typeof fields === "string") {
       fields = [fields];
@@ -729,6 +757,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createGeoIndex(fields: string[] | string, opts?: any) {
     if (typeof fields === "string") {
       fields = [fields];
@@ -744,6 +776,10 @@ export abstract class BaseCollection<T extends object = any>
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link BaseCollection.ensureIndex} instead.
+   */
   createFulltextIndex(fields: string[] | string, minLength?: number) {
     if (typeof fields === "string") {
       fields = [fields];
@@ -849,7 +885,15 @@ export class EdgeCollection<T extends object = any> extends BaseCollection<T> {
     return this.document(documentHandle, opts) as Promise<Edge<T>>;
   }
 
+  /**
+   *
+   */
   save(data: T | Array<T>, opts?: InsertOptions | boolean): Promise<any>;
+  /**
+   * @deprecated This variant of the save method will be removed in arangojs 7.
+   * Pass the `fromId` and `toId` using the `_from` and `_to` properties of
+   * the `data` object instead.
+   */
   save(
     data: T | Array<T>,
     fromId: DocumentHandle,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,4 +1,5 @@
 import { stringify as querystringify } from "querystring";
+import { LinkedList } from "x3-linkedlist";
 import { ArangoError, HttpError } from "./error";
 import {
   ArangojsResponse,
@@ -8,7 +9,6 @@ import {
 } from "./util/request";
 import { sanitizeUrl } from "./util/sanitizeUrl";
 import { Errback } from "./util/types";
-import { LinkedList } from "x3-linkedlist";
 
 const MIME_JSON = /\/(json|javascript)(\W|$)/;
 const LEADER_ENDPOINT_HEADER = "x-arango-endpoint";
@@ -83,6 +83,7 @@ export type Config =
   | string[]
   | Partial<{
       url: string | string[];
+      /** @deprecated Support for isAbsolute will be removed in arangojs 7. */
       isAbsolute: boolean;
       arangoVersion: number;
       loadBalancingStrategy: LoadBalancingStrategy;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -78,7 +78,17 @@ export class ArrayCursor {
     return this._result.splice(0, this._result.length);
   }
 
-  async each(
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link ArrayCursor.forEach} instead.
+   */
+  each(
+    fn: (value: any, index: number, self: ArrayCursor) => boolean | void
+  ): Promise<boolean> {
+    return this.forEach(fn);
+  }
+
+  async forEach(
     fn: (value: any, index: number, self: ArrayCursor) => boolean | void
   ): Promise<boolean> {
     let index = 0;
@@ -110,6 +120,10 @@ export class ArrayCursor {
     return true;
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link ArrayCursor.forEach} instead.
+   */
   async some(
     fn: (value: any, index: number, self: ArrayCursor) => boolean
   ): Promise<boolean> {

--- a/src/database.ts
+++ b/src/database.ts
@@ -336,6 +336,11 @@ export class Database {
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * The behavior can be emulated by invoking {@link BaseCollection.truncate}
+   * on each collection explicitly.
+   */
   async truncate(excludeSystem: boolean = true) {
     const collections = await this.listCollections(excludeSystem);
     return await Promise.all(
@@ -353,7 +358,15 @@ export class Database {
   //#endregion
 
   //#region views
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link Database.view} instead.
+   */
   arangoSearchView(viewName: string): ArangoSearchView {
+    return this.view(viewName);
+  }
+
+  view(viewName: string): ArangoSearchView {
     return new ArangoSearchView(this._connection, viewName);
   }
 
@@ -584,16 +597,21 @@ export class Database {
     );
   }
 
-  queryTracking(): Promise<QueryTracking> {
+  queryTracking(opts?: QueryTrackingOptions): Promise<QueryTracking> {
     return this._connection.request(
       {
-        method: "GET",
-        path: "/_api/query/properties"
+        method: opts ? "PUT" : "GET",
+        path: "/_api/query/properties",
+        body: opts
       },
       res => res.body
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link Database.queryTracking} instead.
+   */
   setQueryTracking(opts?: QueryTrackingOptions): Promise<QueryTracking> {
     return this._connection.request(
       {
@@ -928,10 +946,10 @@ export class Database {
     return result2;
   }
 
-  enableServiceDevelopmentMode(mount: string) {
+  setServiceDevelopmentMode(mount: string, enabled: boolean = true) {
     return this._connection.request(
       {
-        method: "POST",
+        method: enabled ? "POST" : "DELETE",
         path: "/_api/foxx/development",
         qs: { mount }
       },
@@ -939,15 +957,20 @@ export class Database {
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link Database.setServiceDevelopmentMode} instead.
+   */
+  enableServiceDevelopmentMode(mount: string) {
+    return this.setServiceDevelopmentMode(mount, true);
+  }
+
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link Database.setServiceDevelopmentMode} instead.
+   */
   disableServiceDevelopmentMode(mount: string) {
-    return this._connection.request(
-      {
-        method: "DELETE",
-        path: "/_api/foxx/development",
-        qs: { mount }
-      },
-      res => res.body
-    );
+    return this.setServiceDevelopmentMode(mount, false);
   }
 
   listServiceScripts(mount: string) {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -42,6 +42,10 @@ export class GraphVertexCollection extends BaseCollection {
     this.graph = graph;
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link GraphVertexCollection.vertex} instead.
+   */
   document(documentHandle: DocumentHandle, graceful: boolean): Promise<any>;
   document(
     documentHandle: DocumentHandle,

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -222,10 +222,7 @@ export class GraphEdgeCollection extends EdgeCollection {
     });
   }
 
-  save(
-    data: Object | Array<Object>,
-    opts?: InsertOptions
-  ): Promise<any>;
+  save(data: Object | Array<Object>, opts?: InsertOptions): Promise<any>;
   save(
     data: Object | Array<Object>,
     fromId: DocumentHandle,

--- a/src/test/18-graph-edges.ts
+++ b/src/test/18-graph-edges.ts
@@ -54,10 +54,16 @@ describe("Manipulating graph edges", function() {
         (e: any) => e.collection === "knows"
       );
       expect(
-        [].concat.apply([], edgeDefinition.map((e: any) => e.from))
+        [].concat.apply(
+          [],
+          edgeDefinition.map((e: any) => e.from)
+        )
       ).to.contain("person");
       expect(
-        [].concat.apply([], edgeDefinition.map((e: any) => e.to))
+        [].concat.apply(
+          [],
+          edgeDefinition.map((e: any) => e.to)
+        )
       ).to.contain("person");
     });
   });
@@ -103,10 +109,16 @@ describe("Manipulating graph edges", function() {
         (e: any) => e.collection === "works_in"
       );
       expect(
-        [].concat.apply([], edgeDefinition.map((e: any) => e.from))
+        [].concat.apply(
+          [],
+          edgeDefinition.map((e: any) => e.from)
+        )
       ).to.contain("person");
       expect(
-        [].concat.apply([], edgeDefinition.map((e: any) => e.to))
+        [].concat.apply(
+          [],
+          edgeDefinition.map((e: any) => e.to)
+        )
       ).to.contain("city");
     });
   });
@@ -128,10 +140,16 @@ describe("Manipulating graph edges", function() {
         (e: any) => e.collection === "knows"
       );
       expect(
-        [].concat.apply([], edgeDefinition.map((e: any) => e.from))
+        [].concat.apply(
+          [],
+          edgeDefinition.map((e: any) => e.from)
+        )
       ).to.contain("person");
       expect(
-        [].concat.apply([], edgeDefinition.map((e: any) => e.to))
+        [].concat.apply(
+          [],
+          edgeDefinition.map((e: any) => e.to)
+        )
       ).to.contain("city");
     });
   });

--- a/src/util/request.node.ts
+++ b/src/util/request.node.ts
@@ -3,7 +3,7 @@ import {
   ClientRequest,
   ClientRequestArgs,
   IncomingMessage,
-  request as httpRequest,
+  request as httpRequest
 } from "http";
 import { Agent as HttpsAgent, request as httpsRequest } from "https";
 import { parse as parseUrl } from "url";
@@ -107,7 +107,7 @@ export function createRequest(
           options,
           (res: IncomingMessage) => {
             const data: Buffer[] = [];
-            res.on("data", (chunk) => data.push(chunk as Buffer));
+            res.on("data", chunk => data.push(chunk as Buffer));
             res.on("end", () => {
               const result = res as ArangojsResponse;
               result.request = req;
@@ -124,7 +124,7 @@ export function createRequest(
         req.on("timeout", () => {
           req.abort();
         });
-        req.on("error", (err) => {
+        req.on("error", err => {
           const error = err as ArangojsError;
           error.request = req;
           if (called) return;
@@ -144,7 +144,7 @@ export function createRequest(
     {
       close() {
         agent.destroy();
-      },
+      }
     }
   );
 }

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -2,7 +2,11 @@ export type Errback<T> = (err: Error | null, result?: T) => void;
 
 // The following types are based on the official @arangodb types
 
-export type KeyGeneratorType = "traditional" | "autoincrement" | "uuid" | "padded";
+export type KeyGeneratorType =
+  | "traditional"
+  | "autoincrement"
+  | "uuid"
+  | "padded";
 
 export interface CollectionChecksum {
   checksum: string;

--- a/src/view.ts
+++ b/src/view.ts
@@ -167,7 +167,17 @@ export class ArangoSearchView extends BaseView {
     );
   }
 
+  /**
+   * @deprecated This method will be removed in arangojs 7.
+   * Use {@link ArangoSearchView.updateProperties} instead.
+   */
   setProperties(
+    properties: ArangoSearchViewPropertiesOptions = {}
+  ): Promise<ArangoSearchViewPropertiesResponse> {
+    return this.updateProperties(properties);
+  }
+
+  updateProperties(
     properties: ArangoSearchViewPropertiesOptions = {}
   ): Promise<ArangoSearchViewPropertiesResponse> {
     return this._connection.request(

--- a/src/view.ts
+++ b/src/view.ts
@@ -78,7 +78,8 @@ export interface ArangoSearchViewPropertiesOptions {
     | {
         field: string;
         asc: boolean;
-      })[];
+      }
+  )[];
   links?: {
     [key: string]: ArangoSearchViewCollectionLink | undefined;
   };


### PR DESCRIPTION
This PR adds deprecation tags for any methods that can be fixed in arangojs 6 and backports some of the renames in a backwards-compatible way.