### PR TITLE
Doc - Fix `collection.exists` indentation

### DIFF
--- a/docs/Drivers/JS/Reference/Collection/README.md
+++ b/docs/Drivers/JS/Reference/Collection/README.md
@@ -16,7 +16,7 @@ See the
 [HTTP API documentation](https://www.arangodb.com/docs/stable/http/collection-getting.html)
 for details.
 
-## collection.exists
+### collection.exists
 
 `async collection.exists(): boolean`
 


### PR DESCRIPTION
The Collection API page has 2 different heading levels for methods, leading to a confusing indentation in the table of contents: 
![image](https://user-images.githubusercontent.com/1073841/86535561-353d8580-beaf-11ea-9d5c-3735e86f2889.png)

This puts the all of the `collection` functions at the same level