### PR TITLE
Implement BatchedArrayCursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Renamed `cursor.nextBatch` to `cursor.batches.next`
+
+- Renamed `cursor.hasMore` to `cursor.batches.hasMore`
+
 - Renamed `db.createArangoSearchView` to `db.createView`
 
 - Renamed `transaction.run` to `transaction.step`
@@ -27,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and `executeTransaction` methods of `Database` objects.
 
 ### Added
+
+- Added `cursor.batches` to provide a batch-wise cursor API
 
 - Added `before` and `after` to the `agentOptions` configuration option ([#585](https://github.com/arangodb/arangojs/issues/585))
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -12,7 +12,7 @@
  * @packageDocumentation
  */
 import { ArangoResponseMetadata, Params } from "./connection";
-import { ArrayCursor } from "./cursor";
+import { ArrayCursor, BatchedArrayCursor } from "./cursor";
 import { Database } from "./database";
 import {
   Document,
@@ -3278,7 +3278,8 @@ export class Collection<T extends object = any>
         path: "/_api/simple/all-keys",
         body: { type, collection: this._name },
       },
-      (res) => new ArrayCursor(this._db, res.body, res.arangojsHostId)
+      (res) =>
+        new BatchedArrayCursor(this._db, res.body, res.arangojsHostId).items
     );
   }
 
@@ -3292,7 +3293,8 @@ export class Collection<T extends object = any>
           collection: this._name,
         },
       },
-      (res) => new ArrayCursor(this._db, res.body, res.arangojsHostId)
+      (res) =>
+        new BatchedArrayCursor(this._db, res.body, res.arangojsHostId).items
     );
   }
 
@@ -3321,7 +3323,8 @@ export class Collection<T extends object = any>
           collection: this._name,
         },
       },
-      (res) => new ArrayCursor(this._db, res.body, res.arangojsHostId)
+      (res) =>
+        new BatchedArrayCursor(this._db, res.body, res.arangojsHostId).items
     );
   }
 
@@ -3492,7 +3495,8 @@ export class Collection<T extends object = any>
           collection: this._name,
         },
       },
-      (res) => new ArrayCursor(this._db, res.body, res.arangojsHostId)
+      (res) =>
+        new BatchedArrayCursor(this._db, res.body, res.arangojsHostId).items
     );
   }
   //#endregion

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -181,9 +181,13 @@ export class BatchedArrayCursor<T = any> {
    *   { batchSize: 1 }
    * );
    * console.log(cursor.hasMore); // true
-   * await cursor.loadAll();
+   * await cursor.batches.loadAll();
    * console.log(cursor.hasMore); // false
    * console.log(cursor.hasNext); // true
+   * for await (const item of cursor) {
+   *   console.log(item);
+   *   // No server roundtrips necessary any more
+   * }
    * ```
    */
   async loadAll(): Promise<void> {

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -1,9 +1,9 @@
 /**
  * ```ts
- * import type { ArrayCursor } from "arangojs/cursor";
+ * import type { ArrayCursor, BatchedArrayCursor } from "arangojs/cursor";
  * ```
  *
- * The "cursor" module provides the {@link ArrayCursor} type for TypeScript.
+ * The "cursor" module provides cursor-related interfaces for TypeScript.
  *
  * @packageDocumentation
  */
@@ -24,31 +24,22 @@ export interface CursorExtras {
   stats?: Dict<any>;
 }
 
-/**
- * The `ArrayCursor` type represents a cursor returned from a
- * {@link Database.query}.
- *
- * When using TypeScript, cursors can be cast to a specific item type in order
- * to increase type safety.
- *
- * @param T - Type to use for each item. Defaults to `any`.
- *
- * @example
- * ```ts
- * const db = new Database();
- * const query = aql`FOR x IN 1..5 RETURN x`;
- * const result = await db.query(query) as ArrayCursor<number>;
- * ```
- */
-export class ArrayCursor<T = any> {
+interface BatchView<T = any> {
+  isEmpty: boolean;
+  more(): Promise<void>;
+  shift(): T | undefined;
+}
+
+export class BatchedArrayCursor<T = any> {
   protected _db: Database;
-  protected _result: LinkedList<any>;
+  protected _batches: LinkedList<LinkedList<any>>;
   protected _count?: number;
   protected _extra: CursorExtras;
   protected _hasMore: boolean;
   protected _id: string | undefined;
   protected _host?: number;
   protected _allowDirtyRead?: boolean;
+  protected _itemsCursor: ArrayCursor<T>;
 
   /**
    * @internal
@@ -66,20 +57,33 @@ export class ArrayCursor<T = any> {
     host?: number,
     allowDirtyRead?: boolean
   ) {
+    const initialBatch = new LinkedList(body.result);
+    const batches = new LinkedList([initialBatch]);
     this._db = db;
-    this._result = new LinkedList(body.result);
+    this._batches = batches;
     this._id = body.id;
     this._hasMore = Boolean(body.id && body.hasMore);
     this._host = host;
     this._count = body.count;
     this._extra = body.extra;
     this._allowDirtyRead = allowDirtyRead;
-  }
-
-  protected async _drain(): Promise<ArrayCursor<T>> {
-    await this._more();
-    if (!this.hasMore) return this;
-    return this._drain();
+    this._itemsCursor = new ArrayCursor(this, {
+      get isEmpty() {
+        return !batches.length;
+      },
+      more: () => this._more(),
+      shift: () => {
+        let batch = batches.first?.value;
+        while (batch && !batch.length) {
+          batches.shift();
+          batch = batches.first?.value;
+        }
+        if (!batch) return undefined;
+        const value = batch.shift();
+        if (!batch.length) batches.shift();
+        return value;
+      },
+    });
   }
 
   protected async _more(): Promise<void> {
@@ -90,14 +94,21 @@ export class ArrayCursor<T = any> {
       host: this._host,
       allowDirtyRead: this._allowDirtyRead,
     });
-    this._result.push(...res.body.result);
+    this._batches.push(new LinkedList(res.body.result));
     this._hasMore = res.body.hasMore;
+  }
+
+  /**
+   * An {@link ArrayCursor} providing item-wise access to the cursor result set.
+   */
+  get items() {
+    return this._itemsCursor;
   }
 
   /**
    * Additional information about the cursor.
    */
-  get extra(): CursorExtras {
+  get extra(): Readonly<CursorExtras> {
     return this._extra;
   }
 
@@ -113,10 +124,511 @@ export class ArrayCursor<T = any> {
    * Whether the cursor has any remaining batches that haven't yet been
    * fetched. If set to `false`, all batches have been fetched and no
    * additional requests to the server will be made when consuming any
-   * remaining items from this cursor.
+   * remaining batches from this cursor.
    */
   get hasMore(): boolean {
     return this._hasMore;
+  }
+
+  /**
+   * Whether the cursor has more batches. If set to `false`, the cursor has
+   * already been depleted and contains no more batches.
+   */
+  get hasNext(): boolean {
+    return this.hasMore || Boolean(this._batches.length);
+  }
+
+  /**
+   * Enables use with `for await` to deplete the cursor by asynchronously
+   * yielding every batch in the cursor's remaining result set.
+   *
+   * **Note**: If the result set spans multiple batches, any remaining batches
+   * will only be fetched on demand. Depending on the cursor's TTL and the
+   * processing speed, this may result in the server discarding the cursor
+   * before it is fully depleted.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(aql`
+   *   FOR user IN users
+   *   FILTER user.isActive
+   *   RETURN user
+   * `);
+   * for await (const users of cursor.batches) {
+   *   for (const user of users) {
+   *     console.log(user.email, user.isAdmin);
+   *   }
+   * }
+   * ```
+   */
+  async *[Symbol.asyncIterator](): AsyncGenerator<T[], undefined, undefined> {
+    while (this.hasNext) {
+      yield this.next() as Promise<T[]>;
+    }
+    return undefined;
+  }
+
+  /**
+   * Loads all remaining batches from the server.
+   *
+   * **Warning**: This may impact memory use when working with very large
+   * query result sets.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 1 }
+   * );
+   * console.log(cursor.hasMore); // true
+   * await cursor.loadAll();
+   * console.log(cursor.hasMore); // false
+   * console.log(cursor.hasNext); // true
+   * ```
+   */
+  async loadAll(): Promise<void> {
+    while (this._hasMore) {
+      await this._more();
+    }
+  }
+
+  /**
+   * Depletes the cursor, then returns an array containing all batches in the
+   * cursor's remaining result list.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 2 }
+   * );
+   * const result = await cursor.batches.all(); // [[1, 2], [3, 4], [5]]
+   * console.log(cursor.hasNext); // false
+   * ```
+   */
+  async all(): Promise<T[][]> {
+    return this.map((batch) => batch);
+  }
+
+  /**
+   * Advances the cursor and returns all remaining values in the cursor's
+   * current batch. If the current batch has already been exhausted, fetches
+   * the next batch from the server and returns it, or `undefined` if the
+   * cursor has been depleted.
+   *
+   * **Note**: If the result set spans multiple batches, any remaining batches
+   * will only be fetched on demand. Depending on the cursor's TTL and the
+   * processing speed, this may result in the server discarding the cursor
+   * before it is fully depleted.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR i IN 1..10 RETURN i`,
+   *   { batchSize: 5 }
+   * );
+   * const firstBatch = await cursor.batches.next(); // [1, 2, 3, 4, 5]
+   * await cursor.next(); // 6
+   * const lastBatch = await cursor.batches.next(); // [7, 8, 9, 10]
+   * console.log(cursor.hasNext); // false
+   * ```
+   */
+  async next(): Promise<T[] | undefined> {
+    while (!this._batches.length && this.hasNext) {
+      await this._more();
+    }
+    if (!this._batches.length) {
+      return undefined;
+    }
+    const batch = this._batches.shift();
+    return batch && [...batch.values()];
+  }
+
+  /**
+   * Advances the cursor by applying the `callback` function to each item in
+   * the cursor's remaining result list until the cursor is depleted or
+   * `callback` returns the exact value `false`. Returns a promise that
+   * evalues to `true` unless the function returned `false`.
+   *
+   * **Note**: If the result set spans multiple batches, any remaining batches
+   * will only be fetched on demand. Depending on the cursor's TTL and the
+   * processing speed, this may result in the server discarding the cursor
+   * before it is fully depleted.
+   *
+   * See also:
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach | `Array.prototype.forEach`}.
+   *
+   * @param callback - Function to execute on each element.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 2 }
+   * );
+   * const result = await cursor.batches.forEach((currentBatch) => {
+   *   for (const value of currentBatch) {
+   *     console.log(value);
+   *   }
+   * });
+   * console.log(result) // true
+   * console.log(cursor.hasNext); // false
+   * ```
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 2 }
+   * );
+   * const result = await cursor.batches.forEach((currentBatch) => {
+   *   for (const value of currentBatch) {
+   *     console.log(value);
+   *   }
+   *   return false; // stop after the first batch
+   * });
+   * console.log(result); // false
+   * console.log(cursor.hasNext); // true
+   * ```
+   */
+  async forEach(
+    callback: (currentBatch: T[], index: number, self: this) => false | void
+  ): Promise<boolean> {
+    let index = 0;
+    while (this.hasNext) {
+      const currentBatch = await this.next();
+      const result = callback(currentBatch!, index, this);
+      index++;
+      if (result === false) return result;
+      if (this.hasNext) await this._more();
+    }
+    return true;
+  }
+
+  /**
+   * Depletes the cursor by applying the `callback` function to each batch in
+   * the cursor's remaining result list. Returns an array containing the
+   * return values of `callback` for each batch.
+   *
+   * **Note**: This creates an array of all return values, which may impact
+   * memory use when working with very large query result sets. Consider using
+   * {@link BatchedArrayCursor.forEach}, {@link BatchedArrayCursor.reduce} or
+   * {@link BatchedArrayCursor.flatMap} instead.
+   *
+   * See also:
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map | `Array.prototype.map`}.
+   *
+   * @param R - Return type of the `callback` function.
+   * @param callback - Function to execute on each element.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 2 }
+   * );
+   * const squares = await cursor.batches.map((currentBatch) => {
+   *   return currentBatch.map((value) => value ** 2);
+   * });
+   * console.log(squares); // [[1, 4], [9, 16], [25]]
+   * console.log(cursor.hasNext); // false
+   * ```
+   */
+  async map<R>(
+    callback: (currentBatch: T[], index: number, self: this) => R
+  ): Promise<R[]> {
+    let index = 0;
+    let result: any[] = [];
+    while (this.hasNext) {
+      const currentBatch = await this.next();
+      result.push(callback(currentBatch!, index, this));
+      index++;
+    }
+    return result;
+  }
+
+  /**
+   * Depletes the cursor by applying the `callback` function to each batch in
+   * the cursor's remaining result list. Returns an array containing the
+   * return values of `callback` for each batch, flattened to a depth of 1.
+   *
+   * **Note**: If the result set spans multiple batches, any remaining batches
+   * will only be fetched on demand. Depending on the cursor's TTL and the
+   * processing speed, this may result in the server discarding the cursor
+   * before it is fully depleted.
+   *
+   * See also:
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap | `Array.prototype.flatMap`}.
+   *
+   * @param R - Return type of the `callback` function.
+   * @param callback - Function to execute on each element.
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 2 }
+   * );
+   * const squares = await cursor.batches.flatMap((currentBatch) => {
+   *   return currentBatch.map((value) => value ** 2);
+   * });
+   * console.log(squares); // [1, 1, 2, 4, 3, 9, 4, 16, 5, 25]
+   * console.log(cursor.hasNext); // false
+   * ```
+   *
+   * @example
+   * ```js
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 1 }
+   * );
+   * const odds = await cursor.batches.flatMap((currentBatch) => {
+   *   if (currentBatch[0] % 2 === 0) {
+   *     return []; // empty array flattens into nothing
+   *   }
+   *   return currentBatch;
+   * });
+   * console.logs(odds); // [1, 3, 5]
+   * ```
+   */
+  async flatMap<R>(
+    callback: (currentBatch: T[], index: number, self: this) => R | R[]
+  ): Promise<R[]> {
+    let index = 0;
+    let result: any[] = [];
+    while (this.hasNext) {
+      const currentBatch = await this.next();
+      const value = callback(currentBatch!, index, this);
+      if (Array.isArray(value)) {
+        result.push(...value);
+      } else {
+        result.push(value);
+      }
+      index++;
+    }
+    return result;
+  }
+
+  /**
+   * Depletes the cursor by applying the `reducer` function to each batch in
+   * the cursor's remaining result list. Returns the return value of `reducer`
+   * for the last batch.
+   *
+   * **Note**: Most complex uses of the `reduce` method can be replaced with
+   * simpler code using {@link BatchedArrayCursor.forEach} or the `for await`
+   * syntax.
+   *
+   * **Note**: If the result set spans multiple batches, any remaining batches
+   * will only be fetched on demand. Depending on the cursor's TTL and the
+   * processing speed, this may result in the server discarding the cursor
+   * before it is fully depleted.
+   *
+   * See also:
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce | `Array.prototype.reduce`}.
+   *
+   * @param R - Return type of the `reducer` function.
+   * @param reducer - Function to execute on each element.
+   * @param initialValue - Initial value of the `accumulator` value passed to
+   * the `reducer` function.
+   *
+   * @example
+   * ```js
+   * function largestValue(baseline, values) {
+   *   return Math.max(baseline, ...values);
+   * }
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 3 }
+   * );
+   * const result = await cursor.batches.reduce(largestValue, 0);
+   * console.log(result); // 5
+   * console.log(cursor.hasNext); // false
+   * const emptyResult = await cursor.batches.reduce(largestValue, 0);
+   * console.log(emptyResult); // 0
+   * ```
+   *
+   * @example
+   * ```js
+   * // BAD! NEEDLESSLY COMPLEX!
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 1 }
+   * );
+   * const result = await cursor.reduce((accumulator, currentBatch) => {
+   *   accumulator[
+   *     currentBatch[0] % 2 === 0 ? "even" : "odd"
+   *   ].push(...currentBatch);
+   *   return accumulator;
+   * }, { odd: [], even: [] });
+   * console.log(result); // { odd: [1, 3, 5], even: [2, 4] }
+   *
+   * // GOOD! MUCH SIMPLER!
+   * const cursor = await db.query(aql`FOR x IN 1..5 RETURN x`);
+   * const odd = [];
+   * const even = [];
+   * for await (const item of cursor) {
+   *   if (currentBatch[0] % 2 === 0) {
+   *     even.push(...currentBatch);
+   *   } else {
+   *     odd.push(...currentBatch);
+   *   }
+   * }
+   * console.log({ odd, even }); // { odd: [1, 3, 5], even: [2, 4] }
+   * ```
+   */
+  async reduce<R>(
+    reducer: (
+      accumulator: R,
+      currentBatch: T[],
+      index: number,
+      self: this
+    ) => R,
+    initialValue: R
+  ): Promise<R>;
+
+  /**
+   * Depletes the cursor by applying the `reducer` function to each batch in
+   * the cursor's remaining result list. Returns the return value of `reducer`
+   * for the last batch.
+   *
+   * **Note**: If the result set spans multiple batches, any remaining batches
+   * will only be fetched on demand. Depending on the cursor's TTL and the
+   * processing speed, this may result in the server discarding the cursor
+   * before it is fully depleted.
+   *
+   * See also:
+   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce | `Array.prototype.reduce`}.
+   *
+   * @param R - Return type of the `reducer` function.
+   * @param reducer - Function to execute on each element.
+   *
+   * @example
+   * ```js
+   * function largestValue(values1, values2) {
+   *   return [Math.max(...values1, ...values2)];
+   * }
+   * const cursor = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 3 }
+   * );
+   * const result = await cursor.batches.reduce(largestValue);
+   * console.log(result); // [5]
+   * console.log(cursor.hasNext); // false
+   * ```
+   *
+   */
+  async reduce<R>(
+    reducer: (
+      accumulator: T[] | R,
+      currentBatch: T[],
+      index: number,
+      self: this
+    ) => R
+  ): Promise<R | undefined>;
+  async reduce<R>(
+    reducer: (
+      accumulator: R,
+      currentBatch: T[],
+      index: number,
+      self: this
+    ) => R,
+    initialValue?: R
+  ): Promise<R | undefined> {
+    let index = 0;
+    if (!this.hasNext) return initialValue;
+    if (initialValue === undefined) {
+      initialValue = (await this.next()) as any;
+      index += 1;
+    }
+    let value = initialValue as R;
+    while (this.hasNext) {
+      const currentBatch = await this.next();
+      value = reducer(value, currentBatch!, index, this);
+      index++;
+    }
+    return value;
+  }
+
+  /**
+   * Kills the cursor and frees up associated database resources.
+   *
+   * This method has no effect if all batches have already been fetched.
+   *
+   * @example
+   * ```js
+   * const cursor1 = await db.query(aql`FOR x IN 1..5 RETURN x`);
+   * console.log(cursor1.hasMore); // false
+   * await cursor1.kill(); // no effect
+   *
+   * const cursor2 = await db.query(
+   *   aql`FOR x IN 1..5 RETURN x`,
+   *   { batchSize: 2 }
+   * );
+   * console.log(cursor2.hasMore); // true
+   * await cursor2.kill(); // cursor is depleted
+   * ```
+   */
+  async kill(): Promise<void> {
+    if (!this.hasNext) return undefined;
+    return this._db.request(
+      {
+        method: "DELETE",
+        path: `/_api/cursor/${this._id}`,
+      },
+      () => {
+        this._hasMore = false;
+        return undefined;
+      }
+    );
+  }
+}
+
+/**
+ * The `ArrayCursor` type represents a cursor returned from a
+ * {@link Database.query}.
+ *
+ * When using TypeScript, cursors can be cast to a specific item type in order
+ * to increase type safety.
+ *
+ * @param T - Type to use for each item. Defaults to `any`.
+ *
+ * @example
+ * ```ts
+ * const db = new Database();
+ * const query = aql`FOR x IN 1..5 RETURN x`;
+ * const result = await db.query(query) as ArrayCursor<number>;
+ * ```
+ */
+export class ArrayCursor<T = any> {
+  protected _batches: BatchedArrayCursor<T>;
+  protected _view: BatchView<T>;
+
+  constructor(batchedCursor: BatchedArrayCursor, view: BatchView<T>) {
+    this._batches = batchedCursor;
+    this._view = view;
+  }
+
+  /**
+   * A {@link BatchedArrayCursor} providing batch-wise access to the cursor
+   * result set.
+   */
+  get batches() {
+    return this._batches;
+  }
+
+  /**
+   * Additional information about the cursor.
+   */
+  get extra(): CursorExtras {
+    return this.batches.extra;
+  }
+
+  /**
+   * The total number of documents in the query result. Only available if the
+   * `count` option was used.
+   */
+  get count(): number | undefined {
+    return this.batches.count;
   }
 
   /**
@@ -124,7 +636,7 @@ export class ArrayCursor<T = any> {
    * already been depleted and contains no more items.
    */
   get hasNext(): boolean {
-    return this.hasMore || Boolean(this._result.length);
+    return this.batches.hasNext;
   }
 
   /**
@@ -167,10 +679,7 @@ export class ArrayCursor<T = any> {
    * ```
    */
   async all(): Promise<T[]> {
-    await this._drain();
-    const result = [...this._result.values()];
-    this._result.clear();
-    return result;
+    return this.batches.flatMap((v) => v);
   }
 
   /**
@@ -192,48 +701,13 @@ export class ArrayCursor<T = any> {
    * ```
    */
   async next(): Promise<T | undefined> {
-    while (!this._result.length && this.hasMore) {
-      await this._more();
+    while (this._view.isEmpty && this.batches.hasMore) {
+      await this._view.more();
     }
-    if (!this._result.length) {
+    if (this._view.isEmpty) {
       return undefined;
     }
-    return this._result.shift();
-  }
-
-  /**
-   * Advances the cursor and returns all remaining values in the cursor's
-   * current batch. If the current batch has already been exhausted, fetches
-   * the next batch from the server and returns it, or `undefined` if the
-   * cursor has been depleted.
-   *
-   * **Note**: If the result set spans multiple batches, any remaining batches
-   * will only be fetched on demand. Depending on the cursor's TTL and the
-   * processing speed, this may result in the server discarding the cursor
-   * before it is fully depleted.
-   *
-   * @example
-   * ```js
-   * const cursor = await db.query(
-   *   aql`FOR i IN 1..10 RETURN i`,
-   *   { batchSize: 5 }
-   * );
-   * const firstBatch = await cursor.nextBatch(); // [1, 2, 3, 4, 5]
-   * await cursor.next(); // 6
-   * const lastBatch = await cursor.nextBatch(); // [7, 8, 9, 10]
-   * console.log(cursor.hasNext); // false
-   * ```
-   */
-  async nextBatch(): Promise<any[] | undefined> {
-    while (!this._result.length && this.hasMore) {
-      await this._more();
-    }
-    if (!this._result.length) {
-      return undefined;
-    }
-    const result = [...this._result.values()];
-    this._result.clear();
-    return result;
+    return this._view.shift();
   }
 
   /**
@@ -277,14 +751,11 @@ export class ArrayCursor<T = any> {
     callback: (currentValue: T, index: number, self: this) => false | void
   ): Promise<boolean> {
     let index = 0;
-    while (this._result.length || this.hasMore) {
-      let result;
-      while (this._result.length) {
-        result = callback(this._result.shift()!, index, this);
-        index++;
-        if (result === false) return result;
-      }
-      if (this.hasMore) await this._more();
+    while (this.hasNext) {
+      const value = await this.next();
+      const result = callback(value!, index, this);
+      index++;
+      if (result === false) return result;
     }
     return true;
   }
@@ -320,12 +791,10 @@ export class ArrayCursor<T = any> {
   ): Promise<R[]> {
     let index = 0;
     let result: any[] = [];
-    while (this._result.length || this.hasMore) {
-      while (this._result.length) {
-        result.push(callback(this._result.shift()!, index, this));
-        index++;
-      }
-      if (this.hasMore) await this._more();
+    while (this.hasNext) {
+      const value = await this.next();
+      result.push(callback(value!, index, this));
+      index++;
     }
     return result;
   }
@@ -373,17 +842,15 @@ export class ArrayCursor<T = any> {
   ): Promise<R[]> {
     let index = 0;
     let result: any[] = [];
-    while (this._result.length || this.hasMore) {
-      while (this._result.length) {
-        const value = callback(this._result.shift()!, index, this);
-        if (Array.isArray(value)) {
-          result.push(...value);
-        } else {
-          result.push(value);
-        }
-        index++;
+    while (this.hasNext) {
+      const value = await this.next();
+      const item = callback(value!, index, this);
+      if (Array.isArray(item)) {
+        result.push(...item);
+      } else {
+        result.push(item);
       }
-      if (this.hasMore) await this._more();
+      index++;
     }
     return result;
   }
@@ -492,27 +959,19 @@ export class ArrayCursor<T = any> {
     initialValue?: R
   ): Promise<R | undefined> {
     let index = 0;
-    if (!this._result.length) return initialValue;
+    if (!this.hasNext) return initialValue;
     if (initialValue === undefined) {
-      if (!this._result.length && !this.hasMore) {
-        await this._more();
-      }
-      initialValue = this._result.shift() as any;
+      const value = (await this.next()) as any;
+      initialValue = value as R;
       index += 1;
     }
-    while (this._result.length || this.hasMore) {
-      while (this._result.length) {
-        initialValue = reducer(
-          initialValue!,
-          this._result.shift()!,
-          index,
-          this
-        );
-        index++;
-      }
-      if (this.hasMore) await this._more();
+    let value = initialValue;
+    while (this.hasNext) {
+      const item = await this.next();
+      value = reducer(value, item!, index, this);
+      index++;
     }
-    return initialValue;
+    return value;
   }
 
   /**
@@ -535,16 +994,6 @@ export class ArrayCursor<T = any> {
    * ```
    */
   async kill(): Promise<void> {
-    if (!this.hasMore) return undefined;
-    return this._db.request(
-      {
-        method: "DELETE",
-        path: `/_api/cursor/${this._id}`,
-      },
-      () => {
-        this._hasMore = false;
-        return undefined;
-      }
-    );
+    return this.batches.kill();
   }
 }

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -100,6 +100,8 @@ export class BatchedArrayCursor<T = any> {
 
   /**
    * An {@link ArrayCursor} providing item-wise access to the cursor result set.
+   *
+   * See also {@link ArrayCursor.batches}.
    */
   get items() {
     return this._itemsCursor;
@@ -615,6 +617,8 @@ export class ArrayCursor<T = any> {
   /**
    * A {@link BatchedArrayCursor} providing batch-wise access to the cursor
    * result set.
+   *
+   * See also {@link BatchedArrayCursor.items}.
    */
   get batches() {
     return this._batches;

--- a/src/cursor.ts
+++ b/src/cursor.ts
@@ -30,6 +30,35 @@ interface BatchView<T = any> {
   shift(): T | undefined;
 }
 
+/**
+ * The `BatchedArrayCursor` provides a batch-wise API to an {@link ArrayCursor}.
+ *
+ * When using TypeScript, cursors can be cast to a specific item type in order
+ * to increase type safety.
+ *
+ * @param T - Type to use for each item. Defaults to `any`.
+ *
+ * @example
+ * ```ts
+ * const db = new Database();
+ * const query = aql`FOR x IN 1..5 RETURN x`;
+ * const cursor = await db.query(query) as ArrayCursor<number>;
+ * const batches = cursor.batches;
+ * ```
+ *
+ * @example
+ * ```js
+ * const db = new Database();
+ * const query = aql`FOR x IN 1..10000 RETURN x`;
+ * const cursor = await db.query(query, { batchSize: 10 });
+ * for await (const batch of cursor.batches) {
+ *   // Process all values in a batch in parallel
+ *   await Promise.all(batch.map(
+ *     value => asyncProcessValue(value)
+ *   ));
+ * }
+ * ```
+ */
 export class BatchedArrayCursor<T = any> {
   protected _db: Database;
   protected _batches: LinkedList<LinkedList<any>>;
@@ -596,6 +625,8 @@ export class BatchedArrayCursor<T = any> {
  * When using TypeScript, cursors can be cast to a specific item type in order
  * to increase type safety.
  *
+ * See also {@link BatchedArrayCursor}.
+ *
  * @param T - Type to use for each item. Defaults to `any`.
  *
  * @example
@@ -603,6 +634,17 @@ export class BatchedArrayCursor<T = any> {
  * const db = new Database();
  * const query = aql`FOR x IN 1..5 RETURN x`;
  * const result = await db.query(query) as ArrayCursor<number>;
+ * ```
+ *
+ * @example
+ * ```js
+ * const db = new Database();
+ * const query = aql`FOR x IN 1..10 RETURN x`;
+ * const cursor = await db.query(query);
+ * for await (const value of cursor) {
+ *   // Process each value asynchronously
+ *   await processValue(value);
+ * }
  * ```
  */
 export class ArrayCursor<T = any> {

--- a/src/database.ts
+++ b/src/database.ts
@@ -34,7 +34,7 @@ import {
   Headers,
   RequestOptions,
 } from "./connection";
-import { ArrayCursor } from "./cursor";
+import { ArrayCursor, BatchedArrayCursor } from "./cursor";
 import { isArangoError } from "./error";
 import {
   EdgeDefinitionOptions,
@@ -2494,7 +2494,12 @@ export class Database {
         timeout,
       },
       (res) =>
-        new ArrayCursor(this, res.body, res.arangojsHostId, allowDirtyRead)
+        new BatchedArrayCursor(
+          this,
+          res.body,
+          res.arangojsHostId,
+          allowDirtyRead
+        ).items
     );
   }
 

--- a/src/test/08-cursors.ts
+++ b/src/test/08-cursors.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { LinkedList } from "x3-linkedlist";
 import { aql } from "../aql";
-import { ArrayCursor } from "../cursor";
+import { ArrayCursor, BatchedArrayCursor } from "../cursor";
 import { Database } from "../database";
 
 const ARANGO_URL = process.env.TEST_ARANGODB_URL || "http://localhost:8529";
@@ -18,7 +18,7 @@ async function sleep(ms: number) {
   });
 }
 
-describe("Cursor API", () => {
+describe("Item-wise Cursor API", () => {
   let db: Database;
   let cursor: ArrayCursor;
   before(() => {
@@ -67,38 +67,40 @@ describe("Cursor API", () => {
     });
     it("returns true after first batch is consumed", async () => {
       const cursor = await db.query(aqlQuery, { batchSize: 1 });
-      expect((cursor as any)._result.length).to.equal(1);
+      expect((cursor.batches as any)._batches.length).to.equal(1);
       cursor.next();
-      expect((cursor as any)._result.length).to.equal(0);
+      expect((cursor.batches as any)._batches.length).to.equal(0);
       expect(cursor.hasNext).to.equal(true);
     });
     it("returns false after last batch is consumed", async () => {
       const cursor = await db.query(aql`FOR i In 0..1 RETURN i`, {
-        batchSize: 1,
+        batchSize: 2,
       });
       expect(cursor.hasNext).to.equal(true);
-      expect((cursor as any)._result.length).to.equal(1);
+      expect((cursor.batches as any)._batches.length).to.equal(1);
       const val1 = await cursor.next();
       expect(val1).to.equal(0);
       expect(cursor.hasNext).to.equal(true);
-      expect((cursor as any)._result.length).to.equal(0);
+      expect((cursor.batches as any)._batches.length).to.equal(1);
       const val2 = await cursor.next();
       expect(val2).to.equal(1);
       expect(cursor.hasNext).to.equal(false);
-      expect((cursor as any)._result.length).to.equal(0);
+      expect((cursor.batches as any)._batches.length).to.equal(0);
     });
     it("returns false after last result is consumed", async () => {
-      const cursor = await db.query("FOR i In 0..1 RETURN i");
+      const cursor = await db.query(aql`FOR i In 0..1 RETURN i`, {
+        batchSize: 2,
+      });
       expect(cursor.hasNext).to.equal(true);
-      expect((cursor as any)._result.length).to.equal(2);
+      expect((cursor.batches as any)._batches.length).to.equal(1);
       const val1 = await cursor.next();
       expect(val1).to.equal(0);
       expect(cursor.hasNext).to.equal(true);
-      expect((cursor as any)._result.length).to.equal(1);
+      expect((cursor.batches as any)._batches.length).to.equal(1);
       const val2 = await cursor.next();
       expect(val2).to.equal(1);
       expect(cursor.hasNext).to.equal(false);
-      expect((cursor as any)._result.length).to.equal(0);
+      expect((cursor.batches as any)._batches.length).to.equal(0);
     });
     it.skip("returns 404 after timeout", async () => {
       const cursor = await db.query(aql`FOR i In 0..1 RETURN i`, {
@@ -106,11 +108,11 @@ describe("Cursor API", () => {
         ttl: 1,
       });
       expect(cursor.hasNext).to.equal(true);
-      expect((cursor as any)._result.length).to.equal(1);
+      expect((cursor as any)._batches.length).to.equal(1);
       const val = await cursor.next();
       expect(val).to.equal(0);
       expect(cursor.hasNext).to.equal(true);
-      expect((cursor as any)._result.length).to.equal(0);
+      expect((cursor as any)._batches.length).to.equal(0);
       await sleep(3000);
       try {
         await cursor.next();
@@ -181,24 +183,200 @@ describe("Cursor API", () => {
       expect(result).to.eql(aqlResult.reduce((a, b) => a + b));
     });
   });
-  describe("cursor.nextBatch", () => {
+  describe("cursor.kill", () => {
+    it("kills the cursor", async () => {
+      const cursor = await db.query(aql`FOR i IN 1..5 RETURN i`, {
+        batchSize: 2,
+      });
+      const { _host: host, _id: id } = cursor as any;
+      expect(cursor.batches.hasMore).to.equal(true);
+      await cursor.kill();
+      expect(cursor.batches.hasMore).to.equal(false);
+      try {
+        await db.request({
+          method: "PUT",
+          path: `/_api/cursor/${id}`,
+          host: host,
+        });
+      } catch (e) {
+        expect(e).to.have.property("errorNum", 1600);
+        return;
+      }
+      expect.fail("should not be able to fetch additional result set");
+    });
+  });
+});
+
+describe("Batch-wise Cursor API", () => {
+  let db: Database;
+  let cursor: BatchedArrayCursor;
+  before(() => {
+    db = new Database({ url: ARANGO_URL, arangoVersion: ARANGO_VERSION });
+  });
+  after(() => {
+    db.close();
+  });
+  beforeEach(async () => {
+    cursor = (await db.query(aqlQuery, { batchSize: 1 })).batches;
+  });
+  describe("for await of cursor", () => {
+    it("returns each next result of the Cursor", async () => {
+      let i = 0;
+      for await (const value of cursor) {
+        expect(value).to.eql([aqlResult[i]]);
+        i += 1;
+      }
+      expect(i).to.equal(aqlResult.length);
+      expect(cursor.hasNext).to.equal(false);
+    });
+  });
+  describe("cursor.all", () => {
+    it("returns an Array of all results", async () => {
+      const values = await cursor.all();
+      expect(values).to.eql(aqlResult.map((v) => [v]));
+    });
+  });
+  describe("cursor.next", () => {
+    it("returns the next result of the Cursor", async () => {
+      const val1 = await cursor.next();
+      expect(val1).to.eql([0]);
+      const val2 = await cursor.next();
+      expect(val2).to.eql([1]);
+    });
+  });
+  describe("cursor.hasNext", () => {
+    it("returns true if the Cursor has more results", async () => {
+      expect(cursor.hasNext).to.equal(true);
+      const val = await cursor.next();
+      expect(val).to.be.an("array");
+      expect(val?.[0]).to.be.a("number");
+    });
+    it("returns false if the Cursor is empty", async () => {
+      await cursor.all();
+      expect(cursor.hasNext).to.equal(false);
+    });
+    it("returns true after first batch is consumed", async () => {
+      const cursor = (await db.query(aqlQuery, { batchSize: 1 })).batches;
+      expect((cursor as any)._batches.length).to.equal(1);
+      cursor.next();
+      expect((cursor as any)._batches.length).to.equal(0);
+      expect(cursor.hasNext).to.equal(true);
+    });
+    it("returns false after last batch is consumed", async () => {
+      const cursor = (
+        await db.query(aql`FOR i In 0..1 RETURN i`, {
+          batchSize: 1,
+        })
+      ).batches;
+      expect(cursor.hasNext).to.equal(true);
+      expect((cursor as any)._batches.length).to.equal(1);
+      const val1 = await cursor.next();
+      expect(val1).to.eql([0]);
+      expect(cursor.hasNext).to.equal(true);
+      expect((cursor as any)._batches.length).to.equal(0);
+      const val2 = await cursor.next();
+      expect(val2).to.eql([1]);
+      expect(cursor.hasNext).to.equal(false);
+      expect((cursor as any)._batches.length).to.equal(0);
+    });
+    it.skip("returns 404 after timeout", async () => {
+      const cursor = await db.query(aql`FOR i In 0..1 RETURN i`, {
+        batchSize: 1,
+        ttl: 1,
+      });
+      expect(cursor.hasNext).to.equal(true);
+      expect((cursor as any)._batches.length).to.equal(1);
+      const val = await cursor.next();
+      expect(val).to.equal(0);
+      expect(cursor.hasNext).to.equal(true);
+      expect((cursor as any)._batches.length).to.equal(0);
+      await sleep(3000);
+      try {
+        await cursor.next();
+      } catch (err) {
+        expect(err.code).to.equal(404);
+        return;
+      }
+      expect.fail();
+    });
+    it("returns false after last result is consumed (with large amount of results)", async () => {
+      const EXPECTED_LENGTH = 100000;
+      async function loadMore(cursor: ArrayCursor, totalLength: number) {
+        await cursor.next();
+        totalLength++;
+        expect(cursor.hasNext).to.equal(totalLength !== EXPECTED_LENGTH);
+        if (cursor.hasNext) {
+          await loadMore(cursor, totalLength);
+        }
+      }
+      const cursor = await db.query(`FOR i In 1..${EXPECTED_LENGTH} RETURN i`);
+      await loadMore(cursor, 0);
+    });
+  });
+  describe("cursor.forEach", () => {
+    it("invokes the callback for each value", async () => {
+      const results: any[] = [];
+      await cursor.forEach((batch) => {
+        results.push(...batch);
+      });
+      expect(results).to.eql(aqlResult);
+    });
+    it("aborts if the callback returns false", async () => {
+      const results: any[] = [];
+      await cursor.forEach((batch) => {
+        results.push(...batch);
+        if (batch[0] === 5) return false;
+        return;
+      });
+      expect(results).to.eql([0, 1, 2, 3, 4, 5]);
+    });
+  });
+  describe("cursor.map", () => {
+    it("maps all result values over the callback", async () => {
+      const results = await cursor.map(([value]) => value * 2);
+      expect(results).to.eql(aqlResult.map((value) => value * 2));
+    });
+  });
+  describe("cursor.flatMap", () => {
+    it("flat-maps all result values over the callback", async () => {
+      const results = await cursor.flatMap(([value]) => [value, value * 2]);
+      expect(results).to.eql(
+        aqlResult
+          .map((value) => [value, value * 2])
+          .reduce((acc, next) => {
+            acc.push(...next);
+            return acc;
+          }, [] as number[])
+      );
+    });
+    it("doesn't choke on non-arrays", async () => {
+      const results = await cursor.flatMap(([value]) => value * 2);
+      expect(results).to.eql(aqlResult.map((value) => value * 2));
+    });
+  });
+  describe("cursor.reduce", () => {
+    it("reduces the result values with the callback", async () => {
+      const result = await cursor.reduce((a, [b]) => a + b, 0);
+      expect(result).to.eql(aqlResult.reduce((a, b) => a + b));
+    });
+  });
+  describe("cursor.next", () => {
     beforeEach(async () => {
-      cursor = await db.query(aql`FOR i IN 1..10 RETURN i`, { batchSize: 5 });
+      cursor = (await db.query(aql`FOR i IN 1..10 RETURN i`, { batchSize: 5 }))
+        .batches;
     });
     it("fetches the next batch when empty", async () => {
-      const result: LinkedList<any> = (cursor as any)._result;
-      expect([...result.values()]).to.eql([1, 2, 3, 4, 5]);
-      expect(cursor).to.have.property("_hasMore", true);
-      result.first = undefined;
-      result.last = undefined;
-      result.length = 0;
-      expect(await cursor.nextBatch()).to.eql([6, 7, 8, 9, 10]);
-      expect(cursor).to.have.property("_hasMore", false);
+      const result: LinkedList<LinkedList<any>> = (cursor as any)._batches;
+      expect([...result.first!.value.values()]).to.eql([1, 2, 3, 4, 5]);
+      expect(cursor.hasMore).to.equal(true);
+      result.clear();
+      expect(await cursor.next()).to.eql([6, 7, 8, 9, 10]);
+      expect(cursor.hasMore).to.equal(false);
     });
     it("returns all fetched values", async () => {
-      expect(await cursor.nextBatch()).to.eql([1, 2, 3, 4, 5]);
-      expect(await cursor.next()).to.equal(6);
-      expect(await cursor.nextBatch()).to.eql([7, 8, 9, 10]);
+      expect(await cursor.next()).to.eql([1, 2, 3, 4, 5]);
+      expect(await cursor.items.next()).to.equal(6);
+      expect(await cursor.next()).to.eql([7, 8, 9, 10]);
     });
   });
   describe("cursor.kill", () => {
@@ -207,9 +385,9 @@ describe("Cursor API", () => {
         batchSize: 2,
       });
       const { _host: host, _id: id } = cursor as any;
-      expect(cursor).to.have.property("_hasMore", true);
+      expect(cursor.batches.hasMore).to.equal(true);
       await cursor.kill();
-      expect(cursor).to.have.property("_hasMore", false);
+      expect(cursor.batches.hasMore).to.equal(false);
       try {
         await db.request({
           method: "PUT",

--- a/src/test/23-aql-queries-stream.ts
+++ b/src/test/23-aql-queries-stream.ts
@@ -43,7 +43,7 @@ describe34("AQL Stream queries", function () {
         stream: true,
       });
       expect(cursor.count).to.equal(undefined);
-      expect((cursor as any)._hasMore).to.equal(true);
+      expect((cursor as any).batches.hasMore).to.equal(true);
     });
     it("supports compact queries with options", async () => {
       let query: any = {
@@ -56,7 +56,7 @@ describe34("AQL Stream queries", function () {
         stream: true,
       });
       expect(cursor.count).to.equal(undefined); // count will be ignored
-      expect((cursor as any)._hasMore).to.equal(true);
+      expect((cursor as any).batches.hasMore).to.equal(true);
     });
   });
   describe("with some data", () => {

--- a/src/test/27-query-management.ts
+++ b/src/test/27-query-management.ts
@@ -75,7 +75,7 @@ describe("Query Management API", function () {
         count: true,
       });
       expect(cursor.count).to.equal(10);
-      expect((cursor as any)._hasMore).to.equal(true);
+      expect((cursor as any).batches.hasMore).to.equal(true);
     });
     it("supports AQB queries", async () => {
       const cursor = await db.query({ toAQL: () => "RETURN 42" });
@@ -102,7 +102,7 @@ describe("Query Management API", function () {
       };
       const cursor = await db.query(query, { batchSize: 2, count: true });
       expect(cursor.count).to.equal(10);
-      expect((cursor as any)._hasMore).to.equal(true);
+      expect((cursor as any).batches.hasMore).to.equal(true);
     });
   });
 


### PR DESCRIPTION
This expands on the batch-wise `ArrayCursor` API by providing batch-wise equivalents to the item-wise methods of `ArrayCursor` and also adds support for fetching all remaining batches.

This may incur some performance penalties compared to the old implementation because batches are represented individually rather than being added to the same `LinkedList` but this should not make any practical difference.