### PR TITLE
Fix: rename "validation" property to "schema" to match Swagger documentation

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -202,7 +202,7 @@ export type CollectionKeyProperties = {
 /**
  * Properties for validating documents in a collection.
  */
-export type ValidationProperties = {
+export type SchemaProperties = {
   /**
    * Type of document validation.
    */
@@ -241,7 +241,7 @@ export type CollectionProperties = {
   /**
    * Properties for validating documents in the collection.
    */
-  validation: ValidationProperties | null;
+  schema: SchemaProperties | null;
   /**
    * (Cluster only.) Write concern for this collection.
    */
@@ -305,7 +305,7 @@ export type CollectionProperties = {
 /**
  * Options for validating collection documents.
  */
-export type ValidationOptions = {
+export type SchemaOptions = {
   /**
    * JSON Schema description of the validation schema for documents.
    */
@@ -336,7 +336,7 @@ export type CollectionPropertiesOptions = {
   /**
    * Options for validating documents in this collection.
    */
-  validation?: ValidationOptions;
+  schema?: SchemaOptions;
   /**
    * (MMFiles only.) Maximum size for each journal or datafile in bytes.
    *
@@ -433,7 +433,7 @@ export type CreateCollectionOptions = {
   /**
    * Options for validating documents in the collection.
    */
-  validation?: ValidationOptions;
+  schema?: SchemaOptions;
   /**
    * (Cluster only.) Unless set to `false`, the server will wait for all
    * replicas to create the collection before returning.


### PR DESCRIPTION
Fixes #680. Rather than just renaming the "validation" property, I thought it made sense to rename the types as well to avoid any potential confusion. The other approach one could take is to rename the property in the request body, but in my opinion, that would just lead to further confusion.

It doesn't look like the tests are running against ArangoDB 3.7 yet (https://github.com/arangodb/arangojs/blob/main/.github/workflows/tests.yml#L12), so I haven't been able to write any tests for this. Happy to do so once 3.7.0 has been officially released.