### PR TITLE
Fixed incorrect HTTP method call in `patch` method.

### DIFF
--- a/src/route.ts
+++ b/src/route.ts
@@ -259,7 +259,7 @@ export class Route {
   patch(...args: any[]): Promise<ArangojsResponse> {
     const path = typeof args[0] === "string" ? args.shift() : undefined;
     const [body, qs, headers] = args;
-    return this.request({ method: "DELETE", path, body, qs, headers });
+    return this.request({ method: "PATCH", path, body, qs, headers });
   }
 
   /**


### PR DESCRIPTION
The `patch` method in `routes.ts` was incorrectly using the `HTTP DELETE` method internally. This PR is a fix for that.