### PR TITLE
Adding `s` to doc to fix error TS2307

### DIFF
--- a/7.1.0/modules/_documents_.html
+++ b/7.1.0/modules/_documents_.html
@@ -67,7 +67,7 @@
 			<section class="tsd-panel tsd-comment">
 				<div class="tsd-comment tsd-typography">
 					<div class="lead">
-						<pre><code class="language-ts"><span class="hljs-keyword">import</span> <span class="hljs-keyword">type</span> { Document, Edge } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;arangojs/document&quot;</span>;</code></pre>
+						<pre><code class="language-ts"><span class="hljs-keyword">import</span> <span class="hljs-keyword">type</span> { Document, Edge } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;arangojs/documents&quot;</span>;</code></pre>
 					</div>
 					<p>The &quot;document&quot; module provides document/edge related types for TypeScript.</p>
 				</div>


### PR DESCRIPTION
error TS2307: Cannot find module 'arangojs:document' or its corresponding type declarations.