### PR TITLE
make tests more robust

### DIFF
--- a/src/test/26-manipulating-views.ts
+++ b/src/test/26-manipulating-views.ts
@@ -92,12 +92,22 @@ describe34("Manipulating views", function () {
   });
   describeNLB("view.rename", () => {
     it("should rename a view", async () => {
-      // view renamign is only implemented for single servers
-      const res = await db.route("/_admin/server/role").get();
-      if (res.body.role !== "SINGLE") return;
       const name = `v2-${Date.now()}`;
-      const info = await view.rename(name);
-      expect(info).to.have.property("name", name);
+      const res = await db.route("/_admin/server/role").get();
+      if (res.body.role === "SINGLE") {
+        // view renaming is only implemented for single servers
+        const info = await view.rename(name);
+        expect(info).to.have.property("name", name);
+      } else {
+        try {
+          await view.rename(name);
+        } catch (e) {
+          // "unsupported operation" in cluster
+          expect(e).to.have.property("errorNum", 1470);
+          return;
+        }
+        expect.fail("should throw");
+      }
     });
   });
   describe("view.drop", () => {

--- a/src/test/26-manipulating-views.ts
+++ b/src/test/26-manipulating-views.ts
@@ -92,6 +92,9 @@ describe34("Manipulating views", function () {
   });
   describeNLB("view.rename", () => {
     it("should rename a view", async () => {
+      // view renamign is only implemented for single servers
+      const res = await db.route("/_admin/server/role").get();
+      if (res.body.role !== "SINGLE") return;
       const name = `v2-${Date.now()}`;
       const info = await view.rename(name);
       expect(info).to.have.property("name", name);


### PR DESCRIPTION
* Do not execute view renaming test in cluster, as view renaming is only supported in single server.
* Make tests for query list operations (list currently running queries, slow queries) a bit more robust, by increasing wait times and by shielding them against other potentially running queries.