### PR TITLE
allow injecting load balancing strategy for tests

### DIFF
--- a/src/test/01-manipulating-databases.ts
+++ b/src/test/01-manipulating-databases.ts
@@ -7,7 +7,7 @@ describe("Manipulating databases", function () {
   let db: Database;
   beforeEach(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
   });
   afterEach(() => {
     db.close();

--- a/src/test/02-accessing-collections.ts
+++ b/src/test/02-accessing-collections.ts
@@ -11,7 +11,7 @@ describe("Accessing collections", function () {
   let builtinSystemCollections: string[];
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
     const collections = await db.listCollections(false);

--- a/src/test/03-accessing-graphs.ts
+++ b/src/test/03-accessing-graphs.ts
@@ -10,7 +10,7 @@ describe("Accessing graphs", function () {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/04-transactions.ts
+++ b/src/test/04-transactions.ts
@@ -11,7 +11,7 @@ describe("Transactions", () => {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
   });
   after(() => {
     db.close();

--- a/src/test/06-managing-functions.ts
+++ b/src/test/06-managing-functions.ts
@@ -9,7 +9,7 @@ describe("Managing functions", function () {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/07-routes.ts
+++ b/src/test/07-routes.ts
@@ -8,7 +8,7 @@ describe("Arbitrary HTTP routes", () => {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
   });
   describe("database.route", () => {
     it("returns a Route instance", () => {
@@ -33,7 +33,7 @@ describe("Route API", function () {
   let collection: DocumentCollection;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
     collection = await db.createCollection(`c_${Date.now()}`);

--- a/src/test/08-cursors.ts
+++ b/src/test/08-cursors.ts
@@ -21,7 +21,7 @@ describe("Item-wise Cursor API", () => {
   before(async () => {
     allCursors = [];
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
   });
   after(async () => {
     await Promise.all(
@@ -238,7 +238,7 @@ describe("Batch-wise Cursor API", () => {
   before(async () => {
     allCursors = [];
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
   });
   after(async () => {
     await Promise.all(

--- a/src/test/09-collection-metadata.ts
+++ b/src/test/09-collection-metadata.ts
@@ -11,7 +11,7 @@ describe("Collection metadata", function () {
   const collectionName = `collection-${Date.now()}`;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
     collection = await db.createCollection(collectionName);

--- a/src/test/10-manipulating-collections.ts
+++ b/src/test/10-manipulating-collections.ts
@@ -9,7 +9,7 @@ describe("Manipulating collections", function () {
   let collection: DocumentCollection;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/11-managing-indexes.ts
+++ b/src/test/11-managing-indexes.ts
@@ -13,7 +13,7 @@ describe("Managing indexes", function () {
   const collectionName = `collection-${Date.now()}`;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
     collection = await db.createCollection(collectionName);

--- a/src/test/12-simple-queries.ts
+++ b/src/test/12-simple-queries.ts
@@ -13,7 +13,7 @@ describe("Simple queries", function () {
   let collection: DocumentCollection;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/13-bulk-imports.ts
+++ b/src/test/13-bulk-imports.ts
@@ -10,7 +10,7 @@ describe("Bulk imports", function () {
   let collectionName = `collection-${Date.now()}`;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
     collection = await db.createCollection(collectionName);

--- a/src/test/14-document-collections.ts
+++ b/src/test/14-document-collections.ts
@@ -10,7 +10,7 @@ describe("DocumentCollection API", function () {
   let collection: DocumentCollection;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/15-edge-collections.ts
+++ b/src/test/15-edge-collections.ts
@@ -14,7 +14,7 @@ describe("EdgeCollection API", function () {
   }>;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/16-graphs.ts
+++ b/src/test/16-graphs.ts
@@ -46,7 +46,7 @@ describe("Graph API", function () {
   const name = `testdb_${Date.now()}`;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/17-graph-vertices.ts
+++ b/src/test/17-graph-vertices.ts
@@ -55,7 +55,7 @@ describe("Manipulating graph vertices", function () {
   let collectionNames: string[];
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/18-graph-edges.ts
+++ b/src/test/18-graph-edges.ts
@@ -10,7 +10,7 @@ describe("Manipulating graph edges", function () {
   let graph: Graph;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
   });

--- a/src/test/19-graph-vertex-collections.ts
+++ b/src/test/19-graph-vertex-collections.ts
@@ -10,7 +10,7 @@ describe("GraphVertexCollection API", function () {
   let collection: GraphVertexCollection;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
     const graph = db.graph(`testgraph_${Date.now()}`);

--- a/src/test/20-graph-edge-collections.ts
+++ b/src/test/20-graph-edge-collections.ts
@@ -10,7 +10,7 @@ describe("GraphEdgeCollection API", function () {
   let collection: GraphEdgeCollection;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
     const graph = db.graph(`testgraph_${Date.now()}`);

--- a/src/test/22-foxx-api.ts
+++ b/src/test/22-foxx-api.ts
@@ -29,7 +29,7 @@ describe("Foxx service", () => {
   let arangoPaths: any;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.installService(
       serviceServiceMount,
       fs.readFileSync(path.resolve("fixtures", "service-service-service.zip"))

--- a/src/test/23-aql-queries-stream.ts
+++ b/src/test/23-aql-queries-stream.ts
@@ -14,7 +14,7 @@ describe34("AQL Stream queries", function () {
   before(async () => {
     allCursors = [];
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/24-accessing-views.ts
+++ b/src/test/24-accessing-views.ts
@@ -12,7 +12,7 @@ describe34("Accessing views", function () {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/25-view-metadata.ts
+++ b/src/test/25-view-metadata.ts
@@ -12,7 +12,7 @@ describe34("View metadata", function () {
   let view: ArangoSearchView;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
     view = db.view(viewName);

--- a/src/test/26-manipulating-views.ts
+++ b/src/test/26-manipulating-views.ts
@@ -15,7 +15,7 @@ describe34("Manipulating views", function () {
   let view: ArangoSearchView;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/27-query-management.ts
+++ b/src/test/27-query-management.ts
@@ -197,15 +197,14 @@ describe("Query Management API", function () {
       const query = "RETURN SLEEP(3)";
       const p1 = db.query(query);
       p1.then((cursor) => allCursors.push(cursor));
-      let tries: number = 0;
       let queries: any;
       // query was dispatched in an async way, so now we need to wait for the query
       // to actually start running on the server
-      while (tries++ < 100) {
+      for (let tries = 0; tries < 100; tries++) {
         // must filter the list here, as there could be other (system) queries
         // ongoing at the same time
         queries = (await db.listRunningQueries()).filter((i: any) => i.query === query);
-        if (queries.length === 1) {
+        if (queries.length > 0) {
           break;
         }
         await sleep(100);

--- a/src/test/27-query-management.ts
+++ b/src/test/27-query-management.ts
@@ -16,9 +16,17 @@ describe("Query Management API", function () {
   before(async () => {
     allCursors = [];
     db = new Database(config);
-    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
+    if (Array.isArray(config.url)) await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
+    // the following makes calls to /_db/${name} on all coordinators, thus waiting
+    // long enough for the database to become available on all instances
+    if (Array.isArray(config.url)) {
+      await db.waitForPropagation(
+        { path: `/_api/version` },
+        10000
+      );
+    }
   });
   after(async () => {
     await Promise.all(

--- a/src/test/27-query-management.ts
+++ b/src/test/27-query-management.ts
@@ -16,7 +16,7 @@ describe("Query Management API", function () {
   before(async () => {
     allCursors = [];
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(dbName);
     db.useDatabase(dbName);
   });

--- a/src/test/28-accessing-analyzers.ts
+++ b/src/test/28-accessing-analyzers.ts
@@ -13,7 +13,7 @@ describe35("Accessing analyzers", function () {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
     builtins.push(...(await db.listAnalyzers()).map((a) => a.name));

--- a/src/test/29-manipulating-analyzers.ts
+++ b/src/test/29-manipulating-analyzers.ts
@@ -10,7 +10,7 @@ describe35("Manipulating analyzers", function () {
   let db: Database;
   before(async () => {
     db = new Database(config);
-    if (Array.isArray(config.url)) await db.acquireHostList();
+    if (Array.isArray(config.url) && config.loadBalancingStrategy !== "NONE") await db.acquireHostList();
     await db.createDatabase(name);
     db.useDatabase(name);
   });

--- a/src/test/_config.ts
+++ b/src/test/_config.ts
@@ -13,7 +13,7 @@ export const config: {
   ? {
       url: ARANGO_URL.split(",").filter((s) => Boolean(s)),
       arangoVersion: ARANGO_VERSION,
-      loadBalancingStrategy: "ROUND_ROBIN",
+      loadBalancingStrategy: (process.env.TEST_ARANGO_LOAD_BALANCING_STRATEGY === "NONE" ? "NONE" : "ROUND_ROBIN"),
     }
   : {
       url: ARANGO_URL,


### PR DESCRIPTION
this can be achieved by setting th environment variable
`TEST_ARANGO_LOAD_BALANCING_STRATEGY` to `NONE` (for load balancing
strategy `NONE`). Otherwise, the default load balancing strategy will be
`ROUND_ROBIN`, as it was before.

setting the environment variable only has an effect when running the test.