### PR TITLE
don't wait for analyzer propagation in 3.6, as it will likely time out

### DIFF
--- a/src/test/28-accessing-analyzers.ts
+++ b/src/test/28-accessing-analyzers.ts
@@ -74,7 +74,7 @@ describe35("Accessing analyzers", function () {
           await analyzer.create({ type: "identity" });
           await db.waitForPropagation(
             { path: `/_api/analyzer/${analyzer.name}` },
-            30000
+            65000
           );
         })
       );

--- a/src/test/28-accessing-analyzers.ts
+++ b/src/test/28-accessing-analyzers.ts
@@ -46,7 +46,7 @@ describe35("Accessing analyzers", function () {
           await analyzer.create({ type: "identity" });
           await db.waitForPropagation(
             { path: `/_api/analyzer/${analyzer.name}` },
-            30000
+            65000
           );
         })
       );


### PR DESCRIPTION
Don't call `/_api/analyzer/${name}` in 3.6, because analyzers are propagated in the cluster with an up-to 60 second delay in that version. Waiting for the analyzers to propagate to all coordinators will very likely make the tests time out.
In 3.7, the analyzer propagation is almost instantenously, so we can rely on the mechanism of calling `/_api/analyzer/${name}` on all coordinators.

Note: this requires that the backend version number is set correctly when running the tests.
In `src/tests/_config.ts`, there is:
```
const ARANGO_VERSION = Number(
  process.env.ARANGO_VERSION || process.env.ARANGOJS_DEVEL_VERSION || 39999
);
```
So `ARANGO_VERSION` should be set to `30600` or `30700` or whatever is accurate when running the tests. Otherwise version `3.99.99` will be assumed!