### PR TITLE
Adds a script to run tests against running docker container

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "typedoc": "^0.20.36",
     "typescript": "^4.2.4",
     "url": "^0.11.0",
+    "wait-on": "^6.0.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.6.0",
     "xunit-file": "^1.0.0"

--- a/scripts/test-with-docker
+++ b/scripts/test-with-docker
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+CONTAINER_NAME="arangojs-test"
+
+function cleanup {
+  docker kill "$CONTAINER_NAME" > /dev/null
+  docker rm "$CONTAINER_NAME" > /dev/null
+}
+
+trap cleanup EXIT
+
+docker run \
+  --detach \
+  --env "ARANGO_NO_AUTH=1" \
+  --name "$CONTAINER_NAME" \
+  -p 127.0.0.1:8529:8529/tcp \
+  arangodb/arangodb
+
+echo "Waiting for ArangoDB..."
+npm exec wait-on http-get://localhost:8529
+
+npm test


### PR DESCRIPTION
Added `./scripts/test-with-docker` script which starts arangodb in a docker container, runs `npm test` and then shuts down the container. This should make it much easier for people to run tests.