### PR TITLE
Fix #630 - trigger collection compaction

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -2558,6 +2558,18 @@ export interface DocumentCollection<T extends Record<string, any> = any>
   dropIndex(
     selector: IndexSelector
   ): Promise<ArangoResponseMetadata & { id: string }>;
+  /**
+   * Triggers compaction for a collection.
+   *
+   * @example
+   * ```js
+   * const db = new Database();
+   * const collection = db.collection("some-collection");
+   * await collection.compact();
+   * // Background compaction is triggered on the collection
+   * ```
+   */
+  compact(): Promise<ArangoResponseMetadata>;
   //#endregion
 }
 
@@ -3988,6 +4000,16 @@ export class Collection<T extends Record<string, any> = any>
       },
       (res) =>
         new BatchedArrayCursor(this._db, res.body, res.arangojsHostId).items
+    );
+  }
+
+  compact() {
+    return this._db.request(
+      {
+        method: "PUT",
+        path: `/_api/collection/${this._name}/compact`
+      },
+      (res) => res.body
     );
   }
   //#endregion


### PR DESCRIPTION
It happens that there is a collection compact route after all !

Method `compact()` added to collection class.