### PR TITLE
Fix typo in the Database close method doc

### DIFF
--- a/src/databases.ts
+++ b/src/databases.ts
@@ -350,7 +350,7 @@ export class Database {
    *
    * // later
    * clearInterval(interval);
-   * system.close();
+   * db.close();
    * ```
    */
   async acquireHostList(overwrite = false): Promise<void> {


### PR DESCRIPTION
It should be `db`, not `system`.