### PR TITLE
Updated test images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,10 @@ jobs:
         module-system: [cjs, esm]
         node-version: [20, 22, 23]
         arangodb-version:
-          - arangodb/arangodb:3.11.12
-          - arangodb/enterprise:3.11.12
-          - arangodb/arangodb:3.12.3
-          - arangodb/enterprise:3.12.3
-          - arangodb/arangodb-test:devel-nightly
+          - arangodb/arangodb:3.11
+          - arangodb/enterprise:3.11
+          - arangodb/arangodb:3.12
+          - arangodb/enterprise:3.12
           - arangodb/enterprise-test:devel-nightly
 
     container:


### PR DESCRIPTION
Starting with 3.12.5, only enterprise is available.