### PR TITLE
fix: retry connection failures instead of only classifying them as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ This driver uses semantic versioning:
   manual `Content-Length` header handling by default and letting `fetch` set it from the request body.
   ([#855](https://github.com/arangodb/arangojs/issues/855))
 
+- Fixed connection failures never being retried. `isSystemError` rejected the error objects thrown by
+  undici because their immediate prototype is not `Error.prototype`, so a refused connection produced
+  `isSafeToRetry: null` and the retry gate — which also governs host failover — was never entered
+  ([#867](https://github.com/arangodb/arangojs/issues/867)).
+
+- Fixed `config.maxRetries` having no effect. It was destructured out of the config without being
+  re-added to the connection's common request options, so the retry budget always fell back to
+  `hosts.length - 1`, and setting it to `false` did not disable retries
+  ([#867](https://github.com/arangodb/arangojs/issues/867)).
+
+- Fixed a possible stack overflow while constructing a `FetchFailedError` when the error's `cause`
+  chain is cyclic ([#867](https://github.com/arangodb/arangojs/issues/867)).
+
 ### Added
 
 - Added `config.forceContentLength` (default `false`). Set to `true` if you see `ECONNRESET` in

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -733,7 +733,11 @@ export class Connection {
     this._agentOptions = agentOptions;
     this._forceContentLength = forceContentLength;
 
-    this._commonRequestOptions = commonRequestOptions;
+    // `maxRetries` is destructured above, so it is absent from `commonRequestOptions` (the rest of the
+    // config) and has to be put back explicitly. Without this it never reaches the request defaults the
+    // retry budget is read from, leaving `config.maxRetries` with no effect in either direction: it can
+    // neither raise the budget nor, when `false`, disable retries.
+    this._commonRequestOptions = { ...commonRequestOptions, maxRetries };
     this._commonFetchOptions = {
       headers: new Headers(headers),
       ...commonFetchOptions,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -37,7 +37,6 @@ export function isNetworkError(error: any): error is NetworkError {
  */
 export function isSystemError(err: any): err is SystemError {
   if (!err || !(err instanceof Error)) return false;
-  if (Object.getPrototypeOf(err) !== Error.prototype) return false;
   const error = err as SystemError;
   if (typeof error.code !== "string") return false;
   if (typeof error.syscall !== "string") return false;
@@ -59,10 +58,19 @@ export function isUndiciError(err: any): err is UndiciError {
 /**
  * @internal
  *
+ * Maximum number of `cause` links {@link isSafeToRetryFailedFetch} will follow.
+ */
+const MAX_CAUSE_CHAIN_DEPTH = 16;
+
+/**
+ * @internal
+ *
  * Determines whether the given failed fetch error cause is safe to retry.
  */
-function isSafeToRetryFailedFetch(error?: Error): boolean | null {
-  if (!error || !error.cause) return null;
+function isSafeToRetryFailedFetch(error?: Error, depth = 0): boolean | null {
+  // Cause chains are short in practice; the limit only prevents unbounded recursion if a chain is
+  // cyclic, which would otherwise overflow the stack inside the FetchFailedError constructor.
+  if (!error || !error.cause || depth >= MAX_CAUSE_CHAIN_DEPTH) return null;
   let cause = error.cause as Error;
   if (isArangoError(cause) || isNetworkError(cause)) {
     return cause.isSafeToRetry;
@@ -77,7 +85,7 @@ function isSafeToRetryFailedFetch(error?: Error): boolean | null {
   if (isUndiciError(cause) && cause.code === "UND_ERR_CONNECT_TIMEOUT") {
     return true;
   }
-  return isSafeToRetryFailedFetch(cause);
+  return isSafeToRetryFailedFetch(cause, depth + 1);
 }
 
 /**

--- a/src/test/36-retrying-connection-errors.ts
+++ b/src/test/36-retrying-connection-errors.ts
@@ -1,0 +1,169 @@
+import { expect } from "chai";
+import { Database } from "../databases.js";
+import { FetchFailedError, isSystemError } from "../errors.js";
+
+/**
+ * Reproduces the error object undici throws when a connection is refused: a `TypeError` with the
+ * underlying system error as its `cause`.
+ *
+ * The system error is deliberately built from an `Error` SUBCLASS, because that is the shape undici
+ * produces — its prototype is not `Error.prototype` itself. That single detail is what previously made
+ * `isSystemError` reject it, so a test using a plain `new Error()` would pass even without the fix.
+ */
+class UndiciSystemError extends Error {
+  code = "ECONNREFUSED";
+  errno = -111;
+  syscall = "connect";
+  address = "127.0.0.1";
+  port = 8529;
+}
+
+function connectionRefused(): TypeError {
+  const cause = new UndiciSystemError("connect ECONNREFUSED 127.0.0.1:8529");
+  return Object.assign(new TypeError("fetch failed"), { cause });
+}
+
+/**
+ * Replaces `globalThis.fetch` so the real host wrapper still runs and builds a real
+ * `FetchFailedError` from the thrown `TypeError`, exercising the production path rather than a stub of
+ * it. `createHost` captures `globalThis.fetch` when the host is created, so this must be installed
+ * before the `Database` is constructed.
+ */
+function withFailingFetch(failures: number) {
+  const original = globalThis.fetch;
+  const state = {
+    attempts: 0,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+  globalThis.fetch = (async () => {
+    state.attempts += 1;
+    if (state.attempts <= failures) throw connectionRefused();
+    return new Response(JSON.stringify({ result: [] }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+  return state;
+}
+
+const REQUEST = {
+  method: "POST",
+  pathname: "/_api/cursor",
+  body: { query: "RETURN 1" },
+} as const;
+
+describe("Retrying connection errors", () => {
+  describe("isSystemError", () => {
+    it("recognises a system error whose prototype is not Error.prototype", () => {
+      const err = new UndiciSystemError("connect ECONNREFUSED 127.0.0.1:8529");
+      // The condition that used to disqualify it.
+      expect(Object.getPrototypeOf(err)).not.to.equal(Error.prototype);
+      expect(isSystemError(err)).to.equal(true);
+    });
+
+    it("still rejects errors that only look similar", () => {
+      expect(isSystemError(new TypeError("fetch failed"))).to.equal(false);
+      expect(isSystemError(new Error("nope"))).to.equal(false);
+      expect(
+        isSystemError({
+          code: "ECONNREFUSED",
+          syscall: "connect",
+          errno: -111,
+        }),
+      ).to.equal(false);
+    });
+  });
+
+  describe("FetchFailedError", () => {
+    it("is safe to retry when a refused connection is the root cause", () => {
+      const err = new FetchFailedError(
+        undefined,
+        new Request("http://localhost:8529"),
+        {
+          cause: connectionRefused(),
+        },
+      );
+      expect(err.isSafeToRetry).to.equal(true);
+    });
+
+    it("returns null rather than overflowing on a cyclic cause chain", () => {
+      const loop: Error & { cause?: unknown } = new Error("loop");
+      loop.cause = loop;
+      const err = new FetchFailedError(
+        undefined,
+        new Request("http://localhost:8529"),
+        {
+          cause: loop as Error,
+        },
+      );
+      expect(err.isSafeToRetry).to.equal(null);
+    });
+  });
+
+  describe("retry behaviour", () => {
+    it("retries a refused connection on the next host", async () => {
+      const fetch = withFailingFetch(1);
+      try {
+        const db = new Database({
+          url: ["http://localhost:8529", "http://localhost:8530"],
+          databaseName: "_system",
+        });
+        await db.request(REQUEST);
+        // One host failed, the request succeeded on the other.
+        expect(fetch.attempts).to.equal(2);
+      } finally {
+        fetch.restore();
+      }
+    });
+
+    it("honours maxRetries with a single host", async () => {
+      const fetch = withFailingFetch(3);
+      try {
+        const db = new Database({
+          url: "http://localhost:8529",
+          databaseName: "_system",
+          maxRetries: 3,
+        });
+        await db.request(REQUEST);
+        expect(fetch.attempts).to.equal(4); // initial + 3 retries
+      } finally {
+        fetch.restore();
+      }
+    });
+
+    it("makes a single attempt when maxRetries is false", async () => {
+      const fetch = withFailingFetch(1);
+      try {
+        const db = new Database({
+          url: ["http://localhost:8529", "http://localhost:8530"],
+          databaseName: "_system",
+          maxRetries: false,
+        });
+        await db.request(REQUEST).then(
+          () => expect.fail("expected the request to reject"),
+          (err) => expect(err).to.be.instanceOf(FetchFailedError),
+        );
+        expect(fetch.attempts).to.equal(1);
+      } finally {
+        fetch.restore();
+      }
+    });
+
+    it("defaults to one attempt per host when maxRetries is unset", async () => {
+      const fetch = withFailingFetch(99);
+      try {
+        const db = new Database({
+          url: ["http://localhost:8529", "http://localhost:8530"],
+          databaseName: "_system",
+        });
+        await db.request(REQUEST).catch(() => undefined);
+        // Unchanged default: the budget is hosts.length - 1, so two attempts in total.
+        expect(fetch.attempts).to.equal(2);
+      } finally {
+        fetch.restore();
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes the three defects reported in #867. Together they mean a refused connection fails on the first attempt with no retry, no host failover, and no way to configure otherwise.

The repro in #867 needs no server and shows the current behavior: `isSafeToRetry: null` for a refused connection, `maxRetries` absent from the connection's request options, and **1** fetch attempt where 6 were configured.

## The changes

**1 — `isSystemError` rejected undici's error objects** (`src/errors.ts`)

The error undici throws has a prototype chain of `Error -> Error -> Object`, so its *immediate* prototype isn't `Error.prototype` and the identity check disqualified it — even though it's an `instanceof Error` and carries `code: 'ECONNREFUSED'`, `syscall: 'connect'`, `errno: -61`, `address` and `port`. As a result `isSafeToRetryFailedFetch` never reached its ECONNREFUSED branch and returned `null`, and the gate in `Connection` requires a truthy `isSafeToRetry`.

I removed the identity check. The remaining conditions (`instanceof Error`, plus `code`/`syscall` strings and a numeric-or-string `errno`) already identify a Node `SystemError` precisely — a `TypeError` or an `ArangoError` won't satisfy them. The neighboring `isUndiciError` doesn't do a prototype identity check either, so it's perhaps more consistent.

(If you'd rather not change `isSystemError`'s semantics, the alternative is to duck-type locally inside `isSafeToRetryFailedFetch` and leave the exported predicate alone... happy to switch it over if you prefer that boundary.)

**2 — `config.maxRetries` never reached the connection** (`src/connection.ts`)

It's destructured out of the config while `_commonRequestOptions` takes the rest — which by construction excludes it, and then the local is never read again. So `_commonRequestOptions.maxRetries` is _always_ `undefined`, the budget always falls back to `hosts.length - 1`, and passing `false` doesn't disable retries.

**The previous default is preserved exactly.** `maxRetries` defaults to `0`, and the budget expression `maxRetries || hosts.length - 1` still yields `hosts.length - 1` for that case. There's a test pinning this relationship so the change can't silently alter default behavior.

**3 — unbounded recursion on a cyclic cause chain** (`src/errors.ts`)

`isSafeToRetryFailedFetch` recursed into `error.cause` with no depth limit, and the `FetchFailedError` constructor calls it, so a cyclic chain overflowed the stack during construction. Added a depth cap of 16. Thought some sort of cap would be better than allowing infinite recursion. Semi-related.

## Tests

New `src/test/36-retrying-connection-errors.ts`, 8 cases, no server required.

Two deliberate choices worth flagging:

- **The fixture's system error is an `Error` subclass**, because that's the shape undici produces. A fixture built with a plain `new Error()` has `Error.prototype` as its immediate prototype and so would pass *even without* fix 1 — the test would have been pointless. The test asserts `Object.getPrototypeOf(err) !== Error.prototype` explicitly so the reason is visible to the next reader.
- **`globalThis.fetch` is stubbed rather than the host**, so the real `createHost` wrapper still runs and builds a genuine `FetchFailedError` from the thrown `TypeError`(`createHost` captures `globalThis.fetch` at construction, so the stub goes in before the `Database`)...

Verified as regression tests: **6 of the 8 fail against the unpatched source**, and all 8 pass with the fix. The two that pass either way are negative controls.

`33-content-length` and `34-agent-options-undici` still pass, matching their result on unmodified `main`. `tsc` is clean.

## Notes

- Prettier flags `src/errors.ts` and `src/connection.ts` on unmodified `main`, so I deliberately didn't run `--write` on them — it would have reformatted a few hundred unrelated lines. I hand-applied prettier's preference within my own diff, and the new test file is fully prettier-clean.
- **Full suite run against ArangoDB 3.12.9 (enterprise), with a baseline for comparison:** clean `main` gives 380 passing / 12 pending / 0 failing; this branch gives 388 passing / 12 pending / 0 failing. Comparing test names one by one, all 380 baseline tests still pass, the same 12 remain pending, and the delta is exactly the 8 new tests. No regressions.
- Happy to split this into three commits if you'd rather take them independently.

